### PR TITLE
Add lb-proxy service

### DIFF
--- a/charts/lb-proxy/chart/.helmignore
+++ b/charts/lb-proxy/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lb-proxy/chart/Chart.yaml
+++ b/charts/lb-proxy/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: lb-proxy
+description: A Helm chart for lb-proxy
+version: 0.1.0

--- a/charts/lb-proxy/chart/templates/_helpers.tpl
+++ b/charts/lb-proxy/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lb-proxy/chart/templates/configmap.yaml
+++ b/charts/lb-proxy/chart/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  haproxy.cfg: |
+    # https://cbonte.github.io/haproxy-dconv/
+    global
+        maxconn 10000
+        log     stdout format raw local0
+        user    haproxy
+
+    resolvers resolv
+        parse-resolv-conf
+
+    listen main
+        bind    :8080
+        bind    [::]:8080
+        mode    tcp
+        log     global
+        option  tcplog
+        option  dontlognull
+
+        timeout client  30s
+        timeout connect 5s
+        timeout server  30s
+        timeout queue   30s
+        {{- if and (not .Values.config.clusterProxy) (not .Values.config.externalProxy) -}}
+        {{ fail "config.clusterProxy or config.externalProxy must be specified" }}
+        {{- end -}}
+        {{- if .Values.config.clusterProxy }}
+        server  clusterproxy  {{ required "config.clusterProxy must be set" .Values.config.clusterProxy }}   check init-addr libc,none resolvers resolv
+        {{- end -}}
+        {{- if .Values.config.externalProxy }}
+        server  externalproxy {{ required "config.externalProxy must be set" .Values.config.externalProxy }} check init-addr libc,none resolvers resolv backup
+        {{- end -}}

--- a/charts/lb-proxy/chart/templates/deployment.yaml
+++ b/charts/lb-proxy/chart/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /usr/local/etc/haproxy/haproxy.cfg
+              name: config
+              subPath: haproxy.cfg
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "chart.fullname" . }}

--- a/charts/lb-proxy/chart/templates/service.yaml
+++ b/charts/lb-proxy/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      port: 80
+      protocol: TCP
+      name: proxy
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/lb-proxy/chart/values.yaml
+++ b/charts/lb-proxy/chart/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 2
+
+config: {}
+  # You must specify at least one of these!
+  # Internal proxy server running inside the cluser to use
+  # clusterProxy: ""
+  # External proxy server to use if the internal proxy is down or not defined
+  # externalProxy: ""
+
+image:
+  repository: haproxy
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "2.4.8-alpine"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi


### PR DESCRIPTION
This is the service CRI-O and Argo will point to and use as http proxy.

The service is responsible for routing the traffic to a real http proxy
server, either running in the cluster and/or a external proxy server. If
both a internal and external proxy server are provided, the external
server is used a backup in case the internal is down.

**Description of your changes:** ^

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
