### PR TITLE
Support overriding yggdrasil values

### DIFF
--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.6
+version: 1.0.7
 
 dependencies:
   - name: argo-cd

--- a/charts/nidhogg/chart/templates/nidhogg.yaml
+++ b/charts/nidhogg/chart/templates/nidhogg.yaml
@@ -18,6 +18,10 @@ spec:
 {{- end }}
     helm:
       version: v3
+      values: |
+        nidhogg:
+          yggdrasil:
+{{ toYaml .Values.yggdrasil | indent 12 }}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
For now this is needed, so we can override the load balancer ip range
and ingress lb ip when installing nidhogg from mukube-configurator.

**Description of your changes:** ^


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed (unsure if and how it should be documented)
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
