### PR TITLE
Nidhogg has to be reverted back to old dependency

### DIFF
--- a/charts/argo-cd/chart/Chart.yaml
+++ b/charts/argo-cd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-cd-proxy-chart
 description: A proxy helm chart for argo cd
 type: application
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   - name: argo-cd

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.7
+version: 1.0.8
 
 dependencies:
-  - name: argo-cd-proxy-chart
-    version: "0.1.0"
-    repository: "https://distributed-technologies.github.io/helm-charts/"
+  - name: argo-cd
+    version: "3.22.1"
+    repository: "https://argoproj.github.io/argo-helm"
   - name: CNI
     version: "v0.3.1"
     repository: "https://distributed-technologies.github.io/helm-repository/"


### PR DESCRIPTION
**Description of your changes:**
Nidhogg has to be reverted back to old dependency since workflow still finds changed chart

Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
