### PR TITLE
Changed cni dependency to point to new helm chart repo

### DIFF
--- a/charts/nidhogg/chart/Chart.lock
+++ b/charts/nidhogg/chart/Chart.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: argo-cd-proxy-chart
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.1.2
-- name: CNI
-  repository: https://distributed-technologies.github.io/helm-repository/
-  version: v0.3.1
-digest: sha256:b563fefa603cc4c76d03754d369803b78ae1f1432a8c7c4309a7eb5cb0ddbbc4
-generated: "2021-11-09T09:15:20.757973409+01:00"
+- name: cni
+  repository: https://distributed-technologies.github.io/helm-charts/
+  version: 0.3.5
+digest: sha256:4ae0510b3bf02e42977c9c95ec746205678327ba85a5619d7f32ce0e6d488d87
+generated: "2021-11-09T12:06:50.447285678+01:00"

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: argo-cd-proxy-chart
     version: "0.1.2"
     repository: "https://distributed-technologies.github.io/helm-charts/"
-  - name: CNI
+  - name: cni
     version: 0.3.5
     repository: "https://distributed-technologies.github.io/helm-charts/"
     condition: 'installCNI'

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -9,6 +9,6 @@ dependencies:
     version: "0.1.2"
     repository: "https://distributed-technologies.github.io/helm-charts/"
   - name: CNI
-    version: "v0.3.1"
-    repository: "https://distributed-technologies.github.io/helm-repository/"
+    version: 0.3.5
+    repository: "https://distributed-technologies.github.io/helm-charts/"
     condition: 'installCNI'

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.9
+version: 1.0.10
 
 dependencies:
   - name: argo-cd-proxy-chart


### PR DESCRIPTION
**Description of your changes:**
Changed so cni dependency now points to our own helm repo

Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
