### PR TITLE
nidhogg: Add lb-proxy as dependency

### DIFF
--- a/charts/nidhogg/chart/Chart.lock
+++ b/charts/nidhogg/chart/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: cni
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.3.5
-digest: sha256:4ae0510b3bf02e42977c9c95ec746205678327ba85a5619d7f32ce0e6d488d87
-generated: "2021-11-09T12:06:50.447285678+01:00"
+- name: lb-proxy
+  repository: https://distributed-technologies.github.io/helm-charts/
+  version: 0.1.0
+digest: sha256:dd84d120bb67c11d86cd9178a9df37b97d388c65277d9d6092d6ac464842c391
+generated: "2021-11-10T10:30:06.864760973+01:00"

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.10
+version: 1.0.11
 
 dependencies:
   - name: argo-cd-proxy-chart
@@ -12,3 +12,7 @@ dependencies:
     version: 0.3.5
     repository: "https://distributed-technologies.github.io/helm-charts/"
     condition: 'installCNI'
+  - name: lb-proxy
+    version: "0.1.0"
+    repository: "https://distributed-technologies.github.io/helm-charts/"
+    condition: 'lb-proxy.enabled'

--- a/charts/nidhogg/chart/values.yaml
+++ b/charts/nidhogg/chart/values.yaml
@@ -4,6 +4,9 @@ yggdrasil:
 
 installCNI: true
 
+lb-proxy:
+  enabled: false
+
 argo-cd-proxy-chart:
   argo-cd:
     controller:


### PR DESCRIPTION
The lb-proxy service needs to start early so CRI-O and Argo can point to
it as use it as http proxy.

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
