### PR TITLE
argo-cd: Support specifying a HTTP proxy server

### DIFF
--- a/charts/argo-cd/chart/Chart.yaml
+++ b/charts/argo-cd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-cd-proxy-chart
 description: A proxy helm chart for argo cd
 type: application
-version: 0.1.2
+version: 0.1.3
 
 dependencies:
   - name: argo-cd

--- a/charts/argo-cd/chart/templates/_helpers.tpl
+++ b/charts/argo-cd/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/argo-cd/chart/templates/configmap.yaml
+++ b/charts/argo-cd/chart/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-cd-proxy-config
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  {{- if .Values.config.httpProxy }}
+  http_proxy: {{ .Values.config.httpProxy | quote }}
+  https_proxy: {{ .Values.config.httpProxy | quote }}
+  {{- $services := list "argocd-application-controller" "argocd-dex-server" "argocd-redis" "argocd-repo-server" "argocd-server" "redis-ha-haproxy" }}
+  {{- range $services -}}
+  {{- $services = append $services (printf "%s-%s" ($.Release.Name | trunc 63 | trimSuffix "-") .) -}}
+  {{- $services = rest $services -}}
+  {{- end }}
+  no_proxy: {{ printf "%s,%s" (join "," $services) (.Values.config.serviceSubnet) | quote }}
+  {{- end -}}

--- a/charts/argo-cd/chart/values.yaml
+++ b/charts/argo-cd/chart/values.yaml
@@ -1,1 +1,15 @@
-# This is a helm chart for argo-cd
+config: {}
+  # HTTP proxy server Argo should use.
+  # http_proxy: http://1.2.3.4:80
+  # Service subnet which shouldn't be proxied
+  # serviceSubnet: 10.96.0.0/12
+
+argo-cd:
+  server:
+    envFrom:
+      - configMapRef:
+          name: argo-cd-proxy-config
+  repoServer:
+    envFrom:
+      - configMapRef:
+          name: argo-cd-proxy-config


### PR DESCRIPTION
This is needed so Argo can run in a air gapped environment where all
traffic must go through a proxy server.

We use a configmap as templating isn't supported in the values file.

**Description of your changes:** ^


Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
