### PR TITLE
nidhogg: Ensure proxy and root certificate values aren't "reverted"

### DIFF
--- a/charts/nidhogg/chart/Chart.lock
+++ b/charts/nidhogg/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: argo-cd-proxy-chart
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 0.1.2
+  version: 0.1.3
 - name: cni
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.3.5
 - name: lb-proxy
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.1.0
-digest: sha256:dd84d120bb67c11d86cd9178a9df37b97d388c65277d9d6092d6ac464842c391
-generated: "2021-11-10T10:30:06.864760973+01:00"
+digest: sha256:685b62af7b08ba115e46fd7247d3959336d5c8ef67770bed285b9563a7d437eb
+generated: "2021-11-12T11:11:29.226968292+01:00"

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.11
+version: 1.0.12
 
 dependencies:
   - name: argo-cd-proxy-chart

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.11
 
 dependencies:
   - name: argo-cd-proxy-chart
-    version: "0.1.2"
+    version: "0.1.3"
     repository: "https://distributed-technologies.github.io/helm-charts/"
   - name: cni
     version: 0.3.5

--- a/charts/nidhogg/chart/templates/nidhogg.yaml
+++ b/charts/nidhogg/chart/templates/nidhogg.yaml
@@ -21,7 +21,7 @@ spec:
       values: |
         nidhogg:
           yggdrasil:
-{{ toYaml .Values.yggdrasil | indent 12 }}
+            {{- toYaml .Values.yggdrasil | nindent 12 }}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Release.Namespace }}

--- a/charts/nidhogg/chart/templates/nidhogg.yaml
+++ b/charts/nidhogg/chart/templates/nidhogg.yaml
@@ -22,6 +22,36 @@ spec:
         nidhogg:
           yggdrasil:
             {{- toYaml .Values.yggdrasil | nindent 12 }}
+          {{- with (index .Values "lb-proxy") }}
+          {{- if .enabled }}
+          lb-proxy:
+            enabled: {{ .enabled }}
+            config:
+              {{- toYaml .config | nindent 14 }}
+          {{- end }}
+          {{- end }}
+          {{- with (index .Values "argo-cd-proxy-chart") }}
+          argo-cd-proxy-chart:
+            {{- if .config }}
+            config:
+              {{- toYaml .config | nindent 14 }}
+            {{- end }}
+            {{- with (index . "argo-cd") }}
+            {{- if or .server.volumeMounts .repoServer.volumeMounts }}
+            argo-cd:
+              server:
+                volumeMounts:
+                  {{- toYaml .server.volumeMounts | nindent 18 }}
+                volumes:
+                  {{- toYaml .server.volumes | nindent 18 }}
+              repoServer:
+                volumeMounts:
+                  {{- toYaml .repoServer.volumeMounts | nindent 18 }}
+                volumes:
+                  {{- toYaml .repoServer.volumes | nindent 18 }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The internal TCP load balancer (lb-proxy subchart), Argo proxy config
(argo-cd-proxy-chart subchart) and custom root certificate
(argo-cd-proxy-chart subchart) are configured by
mukube-configurator[1][2] by setting values.

This means the values must stay in place, so pass them to the nidhogg
Argo application.

[1] https://github.com/distributed-technologies/mukube-configurator/pull/36
[2] https://github.com/distributed-technologies/mukube-configurator/pull/37

**Description of your changes:** ^


Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
