### PR TITLE
Feature/non conflicting names

### DIFF
--- a/charts/artifact-registry/README.md
+++ b/charts/artifact-registry/README.md
@@ -1,9 +1,2 @@
-# services-artifact-registry
+# artifact-registry
 A registry setup for both helm charts and container images.
-
-
-Add the registry with the name `local-helm-registry` use command:  
-`helm repo add local-helm-registry http://<IP>:<PORT>`
-
-If the index.yaml file is present on the fileserver you should be able to install the helm chart:  
-`helm install local-helm-registry/chart --generate-name`

--- a/charts/artifact-registry/chart/Chart.yaml
+++ b/charts/artifact-registry/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: chart
+name: artifact-repository
 description: A Helm chart for artifact storage
-version: v0.1.0
+version: 0.1.1
 appVersion: "1.16.0"

--- a/charts/artifact-registry/chart/templates/cm-nginx.yaml
+++ b/charts/artifact-registry/chart/templates/cm-nginx.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: helm-server-nginx-conf
 data:
   nginx.conf: |
     events {

--- a/charts/artifact-registry/chart/templates/deployment-helm-server.yaml
+++ b/charts/artifact-registry/chart/templates/deployment-helm-server.yaml
@@ -40,7 +40,7 @@ spec:
       volumes:
       - name: nginx-conf
         configMap:
-          name: nginx-conf
+          name: helm-server-nginx-conf
           items:
             - key: nginx.conf
               path: nginx.conf

--- a/charts/artifact-registry/chart/values.yaml
+++ b/charts/artifact-registry/chart/values.yaml
@@ -3,7 +3,7 @@ helmServer:
   replicaCount: 1
   image:
     repository: nginx
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: 1.21.3
   service:
     type: ClusterIP
@@ -25,7 +25,7 @@ imageRegistry:
   replicaCount: 1
   image:
     repository: registry
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     tag: "2.7"
   service:
     type: ClusterIP

--- a/charts/git-server/chart/Chart.yaml
+++ b/charts/git-server/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: git-server
 description: A Helm chart for a Git ssh server in Kubernetes
-version: 0.2.2
+version: 0.2.3

--- a/charts/git-server/chart/templates/cm-nginx.yaml
+++ b/charts/git-server/chart/templates/cm-nginx.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: git-server-nginx-conf
 data:
   nginx.conf: |
     user                    nginx;

--- a/charts/git-server/chart/templates/deployment-git-server.yaml
+++ b/charts/git-server/chart/templates/deployment-git-server.yaml
@@ -44,7 +44,7 @@ spec:
             claimName: git-server-data-pvc
         - name: nginx-conf-volume
           configMap:
-            name: nginx-conf
+            name: git-server-nginx-conf
             items:
               - key: nginx.conf
                 path: nginx.conf


### PR DESCRIPTION
**Description of your changes:**
When deploying the charts in the same namespace they conflict because the configmaps were named the same. 

The artifact-repository chart name was changed. Before, the chart was wrongly named, and thus released as "chart".  Also, changed to SemVer versioning. 

Updated the README. 

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
