### PR TITLE
nidhogg: Remove chart repositories from Argo

### DIFF
--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.12
+version: 1.0.13
 
 dependencies:
   - name: argo-cd-proxy-chart

--- a/charts/nidhogg/chart/values.yaml
+++ b/charts/nidhogg/chart/values.yaml
@@ -22,31 +22,6 @@ argo-cd-proxy-chart:
     server:
       replicas: 3
       config:
-        repositories: |
-          - type: helm
-            url: https://argoproj.github.io/argo-helm
-            name: argoproj
-          - type: helm
-            url: https://distributed-technologies.github.io/helm-repository/
-            name: dt-helmrepo
-          - type: helm
-            url: https://kubernetes.github.io/kube-state-metrics
-            name: metrics
-          - type: helm
-            url: https://prometheus-community.github.io/helm-charts
-            name: node-exporter
-          - type: helm
-            url: https://grafana.github.io/helm-charts
-            name: grafana
-          - type: helm
-            url: https://strimzi.io/charts/
-            name: strimzi-kafka-operator
-          - type: helm
-            url: https://confluentinc.github.io/cp-helm-charts/
-            name: cp-helm-charts
-          - type: helm
-            url: https://charts.rook.io/release
-            name: rook-release
         resource.customizations: |
           admissionregistration.k8s.io/MutatingWebhookConfiguration:
             ignoreDifferences: |


### PR DESCRIPTION
They aren't needed as we packaging the dependencies and Argo fails
deploying if they can't be reached (ex: in a air-gapped environment).

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
