### PR TITLE
workflow: Rename branches for automatic dep updates

### DIFF
--- a/.github/workflows/dependency-checker.yaml
+++ b/.github/workflows/dependency-checker.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ matrix.path }}-dep-upgrade-${{ steps.run-script.outputs.version }}-to-${{ steps.run-script.outputs.highestversion }}
+          branch: update/${{ matrix.path }}-dep-${{ steps.run-script.outputs.name }}-from-${{ steps.run-script.outputs.version }}-to-${{ steps.run-script.outputs.highestversion }}
           base: main
           delete-branch: true
           title: Dependency update ${{ steps.run-script.outputs.name }} from ${{ steps.run-script.outputs.version }} to ${{ steps.run-script.outputs.highestversion }}.


### PR DESCRIPTION
Prefix the branch names with `update/`. With this change the update branches will be easily identifiable and grouped at the end when listing branches.

Checklist:

* [ ] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
