### PR TITLE
ntp: Support overriding the NTP server

### DIFF
--- a/charts/ntp/chart/Chart.yaml
+++ b/charts/ntp/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: ntp
-version: 0.1.3
+version: 0.1.4
 description: A helm chart for our ntp-server

--- a/charts/ntp/chart/templates/daemonset.yaml
+++ b/charts/ntp/chart/templates/daemonset.yaml
@@ -34,9 +34,9 @@ spec:
           args:
             - client
           env:
-            - name: NTP_SERVER
+            - name: INTERNAL_NTP_SERVER
               value: "{{ include "chart.fullname" . }}.{{ .Release.Namespace }}"
-            - name: NTP_SERVERS
+            - name: INTERNAL_NTP_SERVERS
               value: {{ .Values.replicaCount | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ntp/chart/templates/deployment.yaml
+++ b/charts/ntp/chart/templates/deployment.yaml
@@ -39,9 +39,13 @@ spec:
           args:
             - server
           env:
+            {{- if .Values.ntp.server }}
             - name: NTP_SERVER
+              value: "{{ .Values.ntp.server }}"
+            {{- end }}
+            - name: INTERNAL_NTP_SERVER
               value: "{{ include "chart.fullname" . }}.{{ .Release.Namespace }}"
-            - name: NTP_SERVERS
+            - name: INTERNAL_NTP_SERVERS
               value: {{ .Values.replicaCount | quote }}
           ports:
             - name: ntp

--- a/charts/ntp/chart/values.yaml
+++ b/charts/ntp/chart/values.yaml
@@ -4,7 +4,11 @@ image:
   repository: ghcr.io/distributed-technologies/helm-charts/ntp
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.3"
+  tag: "0.1.4"
+
+ntp: {}
+  # Override the NTP server (ex: a internal NTP server)
+  # server: pool.ntp.org
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/ntp/container/chrony-client.conf
+++ b/charts/ntp/container/chrony-client.conf
@@ -1,4 +1,4 @@
-pool {{NTP_SERVER}} iburst maxsources {{NTP_SERVERS}}
+pool {{INTERNAL_NTP_SERVER}} iburst maxsources {{INTERNAL_NTP_SERVERS}}
 
 #######################################################################
 ### AVOIDING POTENTIALLY BOGUS CHANGES TO YOUR CLOCK

--- a/charts/ntp/container/chrony-server.conf
+++ b/charts/ntp/container/chrony-server.conf
@@ -1,6 +1,6 @@
 # https://www.ntppool.org/
-pool pool.ntp.org iburst
-pool {{NTP_SERVER}} iburst maxsources {{NTP_SERVERS}}
+pool {{NTP_SERVER}} iburst
+pool {{INTERNAL_NTP_SERVER}} iburst maxsources {{INTERNAL_NTP_SERVERS}}
 
 #######################################################################
 ### AVOIDING POTENTIALLY BOGUS CHANGES TO YOUR CLOCK

--- a/charts/ntp/container/docker-entrypoint.sh
+++ b/charts/ntp/container/docker-entrypoint.sh
@@ -3,15 +3,16 @@ set -o errexit
 
 case "${1}" in
   client)
-    if [ -z "NTP_SERVER" ] || [ -z "NTP_SERVERS" ]; then
-      echo "Please set \$NTP_SERVER and \$NTP_SERVERS"
+    if [ -z "$INTERNAL_NTP_SERVER" ] || [ -z "$INTERNAL_NTP_SERVERS" ]; then
+      echo "Please set \$INTERNAL_NTP_SERVER and \$INTERNAL_NTP_SERVERS"
       exit 1
     fi
-    sed -e "s/{{NTP_SERVER}}/$NTP_SERVER/" -e "s/{{NTP_SERVERS}}/$NTP_SERVERS/" -i /etc/chrony/chrony-client.conf
+    sed -e "s/{{INTERNAL_NTP_SERVER}}/$INTERNAL_NTP_SERVER/" -e "s/{{INTERNAL_NTP_SERVERS}}/$INTERNAL_NTP_SERVERS/" -i /etc/chrony/chrony-client.conf
     exec chronyd -U -d -f /etc/chrony/chrony-client.conf
     ;;
   server)
-    sed -e "s/{{NTP_SERVER}}/$NTP_SERVER/" -e "s/{{NTP_SERVERS}}/$NTP_SERVERS/" -i /etc/chrony/chrony-server.conf
+    NTP_SERVER="${NTP_SERVER:-pool.ntp.org}"
+    sed -e "s/{{NTP_SERVER}}/$NTP_SERVER/" -e "s/{{INTERNAL_NTP_SERVER}}/$INTERNAL_NTP_SERVER/" -e "s/{{INTERNAL_NTP_SERVERS}}/$INTERNAL_NTP_SERVERS/" -i /etc/chrony/chrony-server.conf
     exec chronyd -x -U -d -f /etc/chrony/chrony-server.conf
     ;;
   *)


### PR DESCRIPTION
This is useful if the cluster is running in a air-gapped environment and
a internal NTP server is available.

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
