### PR TITLE
Feature/kafka ha

### DIFF
--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.0
+version: 1.1.1
 
 dependencies:
 - name: strimzi-kafka-operator

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -11,6 +11,15 @@ spec:
         metadata:
           labels:
             app: kafka-broker
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: kafka-broker
+                  topologyKey: "kubernetes.io/hostname"
     replicas: {{ .Values.cluster.kafka.replicas }}
     version: {{ .Values.cluster.kafka.version }} 
     logging: 
@@ -58,6 +67,15 @@ spec:
         metadata:
           labels:
             app: kafka-zookeeper
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: kafka-zookeeper
+                  topologyKey: "kubernetes.io/hostname"
     replicas: {{ .Values.cluster.zookeeper.replicas }}
     logging:
       type: inline
@@ -77,8 +95,6 @@ spec:
         configMapKeyRef:
           name: kafka-metrics
           key: zookeeper-metrics-config.yml
-      
-
   entityOperator: 
     tlsSidecar: 
       resources: {{ .Values.cluster.entityOperator.tlsSidecar.resources | toYaml | nindent 8 }}

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -72,12 +72,30 @@ cp-helm-charts:
       url: http://kafka-cp-schema-registry:8081
     kafka:
       bootstrapServers: my-cluster-kafka-bootstrap:9092
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: cp-ksql-server
+              topologyKey: "kubernetes.io/hostname"
   cp-schema-registry:
     enabled: true
     image: confluentinc/cp-schema-registry
     imageTag: 6.2.1
     kafka:
       bootstrapServers: my-cluster-kafka-bootstrap:9092
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: cp-schema-registry
+              topologyKey: "kubernetes.io/hostname"
   cp-control-center:
     enabled: false
 


### PR DESCRIPTION
**Description of your changes:**

We have added node antiAffinity for all Kafka resources so that entities are spread across nodes for high availability.
Rack awareness did not seem to work as intended.

Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
