### PR TITLE
nidhogg: Bump CNI

### DIFF
--- a/charts/nidhogg/chart/Chart.lock
+++ b/charts/nidhogg/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.3
 - name: cni
   repository: https://distributed-technologies.github.io/helm-charts/
-  version: 0.3.5
+  version: 1.0.0
 - name: lb-proxy
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.1.0
-digest: sha256:685b62af7b08ba115e46fd7247d3959336d5c8ef67770bed285b9563a7d437eb
-generated: "2021-11-12T11:11:29.226968292+01:00"
+digest: sha256:04c797867a6c915e68c4b31bb35ec2653599f79e9784d235a4ba760ebe6cdae6
+generated: "2022-01-31T13:20:49.093452441+01:00"

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.15
+version: 1.0.16
 
 dependencies:
   - name: argo-cd-proxy-chart
     version: "0.1.3"
     repository: "https://distributed-technologies.github.io/helm-charts/"
   - name: cni
-    version: 0.3.5
+    version: 1.0.0
     repository: "https://distributed-technologies.github.io/helm-charts/"
     condition: 'installCNI'
   - name: lb-proxy


### PR DESCRIPTION
0335867 ("cni: Switch CNI to Cilium from Weave Net")[1]

[1] https://github.com/distributed-technologies/helm-charts/pull/224

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
   * It has been tested without Argo, but traffic is flowing.
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
