### PR TITLE
Fix/kafka operator memory

### DIFF
--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.1
+version: 1.1.2
 
 dependencies:
 - name: strimzi-kafka-operator
-  version: "0.26.1"
+  version: "0.27.1"
   repository: "https://strimzi.io/charts/"
 - name: prometheus-kafka-exporter
   version: "1.1.0"

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -26,7 +26,9 @@ spec:
       type: inline
       loggers:
         kafka.root.logger.level: "INFO"
-    resources: {{ .Values.cluster.kafka.resources | toYaml | nindent 6 }}
+    {{- if .Values.cluster.kafka.resources }}
+    resources: {{- .Values.cluster.kafka.resources | toYaml | nindent 6 }}
+    {{- end }}
     readinessProbe: 
       initialDelaySeconds: 15
       timeoutSeconds: 5
@@ -81,7 +83,9 @@ spec:
       type: inline
       loggers:
         zookeeper.root.logger: "INFO"
-    resources: {{ .Values.cluster.zookeeper.resources | toYaml | nindent 6 }}
+    {{- if .Values.cluster.zookeeper.resources }}
+    resources: {{- .Values.cluster.zookeeper.resources | toYaml | nindent 6 }}
+    {{- end }}
     jvmOptions:
       -Xms: 4096m
       -Xmx: 4096m
@@ -97,7 +101,9 @@ spec:
           key: zookeeper-metrics-config.yml
   entityOperator: 
     tlsSidecar: 
-      resources: {{ .Values.cluster.entityOperator.tlsSidecar.resources | toYaml | nindent 8 }}
+      {{- if .Values.cluster.entityOperator.tlsSidecar.resources }}
+      resources: {{- .Values.cluster.entityOperator.tlsSidecar.resources | toYaml | nindent 8 }}
+      {{- end }}
     topicOperator:
       watchedNamespace: {{ .Release.Namespace }}
       reconciliationIntervalSeconds: 60
@@ -105,7 +111,9 @@ spec:
         type: inline
         loggers:
           rootLogger.level: "INFO"
-      resources: {{ .Values.cluster.entityOperator.topicOperator.resources | toYaml | nindent 8 }}
+      {{- if .Values.cluster.entityOperator.topicOperator.resources }}
+      resources: {{- .Values.cluster.entityOperator.topicOperator.resources | toYaml | nindent 8 }}
+      {{- end }}
     userOperator:
       watchedNamespace: {{ .Release.Namespace }}
       reconciliationIntervalSeconds: 60
@@ -113,8 +121,12 @@ spec:
         type: inline
         loggers:
           rootLogger.level: INFO
-      resources: {{ .Values.cluster.entityOperator.userOperator.resources | toYaml | nindent 8 }}
+      {{- if .Values.cluster.entityOperator.userOperator.resources }}
+      resources: {{- .Values.cluster.entityOperator.userOperator.resources | toYaml | nindent 8 }}
+      {{- end }}
   kafkaExporter:
     topicRegex: ".*"
     groupRegex: ".*"
-    resources: {{ .Values.cluster.kafkaExporter.resources | toYaml | nindent 6 }}
+    {{- if .Values.cluster.kafkaExporter.resources }}
+    resources: {{- .Values.cluster.kafkaExporter.resources | toYaml | nindent 6 }}
+    {{- end }}

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -2,6 +2,9 @@ env: prod
 # Docs https://github.com/strimzi/strimzi-kafka-operator/blob/main/helm-charts/helm3/strimzi-kafka-operator/values.yaml
 strimzi-kafka-operator:
   generateNetworkPolicy: false
+  extraEnvs:
+    - name: JAVA_OPTS
+      value: "-Xms80m -Xmx80m"
 cluster:
   name: my-cluster
   kafka:

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -1,5 +1,7 @@
 env: prod
 # Docs https://github.com/strimzi/strimzi-kafka-operator/blob/main/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+strimzi-kafka-operator:
+  generateNetworkPolicy: false
 cluster:
   name: my-cluster
   kafka:


### PR DESCRIPTION
Update to a new version of strimzi that supports passing env options to the JVM running the kafka-operator. 
The operator would get OOM-killed because the JVM was not configured properly, and we set reasonable options
discussed in https://github.com/strimzi/strimzi-kafka-operator/issues/4471.

Additionally, disabling the automatically generated network policy. For some reason the generated network policy
does not function as expected after we have implemented cilium. And e.g. the node-exporter could not contact 
the zookeeper. We need to investigate this issue and should later reimplement a network policy.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
