### PR TITLE
Add proxy chart for kube-state-metrics

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -17,6 +17,7 @@ chart-dirs:
   - charts/ha-proxy
   - charts/jaeger
   - charts/kafka
+  - charts/kube-state-metrics
   - charts/loki
   - charts/ntp
   - charts/prometheus
@@ -37,7 +38,7 @@ chart-repos:
   - jaeger=https://jaegertracing.github.io/helm-charts
   - common=https://charts.bitnami.com/bitnami
   - kafka=https://strimzi.io/charts/
-  - kafkaexport=https://prometheus-community.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
   - cp=https://confluentinc.github.io/cp-helm-charts/
   - thanos=https://kubernetes-charts.banzaicloud.com
   - traefik=https://helm.traefik.io/traefik

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -21,6 +21,7 @@ chart-dirs:
   - charts/harbor
   - charts/jaeger
   - charts/kafka
+  - charts/kube-state-metrics
   - charts/lb-proxy
   - charts/lightvessel
   - charts/loadbalancer
@@ -46,7 +47,7 @@ chart-repos:
   - jaeger=https://jaegertracing.github.io/helm-charts
   - common=https://charts.bitnami.com/bitnami
   - kafka=https://strimzi.io/charts/
-  - kafkaexport=https://prometheus-community.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
   - cp=https://confluentinc.github.io/cp-helm-charts/
   - thanos=https://kubernetes-charts.banzaicloud.com
   - traefik=https://helm.traefik.io/traefik

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -1,0 +1,3 @@
+# kube-state-metrics
+
+Proxy chart for [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics).

--- a/charts/kube-state-metrics/chart/.helmignore
+++ b/charts/kube-state-metrics/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kube-state-metrics/chart/Chart.yaml
+++ b/charts/kube-state-metrics/chart/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: kube-state-metrics
+description: A Helm chart for kube-state-metrics
+type: application
+version: 0.1.0
+
+dependencies:
+- name: kube-state-metrics
+  version: "4.5.0"
+  repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/kube-state-metrics/chart/values.yaml
+++ b/charts/kube-state-metrics/chart/values.yaml
@@ -1,0 +1,6 @@
+kube-state-metrics:
+  ## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+  # releaseLabel: false
+  prometheus:
+    monitor:
+      enabled: true


### PR DESCRIPTION
kube-state-metrics can help monitoring k8s objects:
"kube-state-metrics (KSM) is a simple service that listens to the
Kubernetes API server and generates metrics about the state of the
objects. [...] It is not focused on the health of the individual
Kubernetes components, but rather on the health of the various objects
inside, such as deployments, nodes and pods."[1]

[1] https://github.com/kubernetes/kube-state-metrics

**Description of your changes:**

`kube-state-metrics` is included in kube-prometheus-stack which we use at the moment and plan to replace with Grafana Agents. So drafted until that is done.

yggdrasil PR: https://github.com/distributed-technologies/yggdrasil/pull/74

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
