### PR TITLE
ntp: Add missing capability preventing chronyd from running

### DIFF
--- a/charts/ntp/chart/Chart.yaml
+++ b/charts/ntp/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: ntp
-version: 0.1.4
+version: 0.1.5
 description: A helm chart for our ntp-server

--- a/charts/ntp/chart/values.yaml
+++ b/charts/ntp/chart/values.yaml
@@ -23,6 +23,7 @@ securityContext:
   capabilities:
     add:
       - SYS_TIME
+      - NET_BIND_SERVICE
     drop:
       - ALL
 


### PR DESCRIPTION
The two capabilities set on the chronyd binary[1], must be allowed for
the binary to run. Due to a bug in CRI-O[2], CAP_NET_BIND_SERVICE was
unintentionally added by the runtime, which explain why the missing
capability wasn't caught in testing.

[1] CAP_SYS_TIME and CAP_NET_BIND_SERVICE
[2] https://github.com/cri-o/cri-o/pull/4923

Fixes: 3536bbf ("ntp: Fix the server can't listen on port 123 as
non-root")

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
