### PR TITLE
Change loki chart dependency to stand alone loki

### DIFF
--- a/charts/loki/chart/Chart.yaml
+++ b/charts/loki/chart/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: loki
 description: A Helm umbrella chart for Loki
 type: application
-version: 0.1.2
+version: 1.0.0
 
 dependencies:
-- name: loki-stack
-  version: "2.3.1"
+- name: loki-distributed
+  version: "0.44.0"
   repository: "https://grafana.github.io/helm-charts"

--- a/charts/loki/chart/values.yaml
+++ b/charts/loki/chart/values.yaml
@@ -1,15 +1,2 @@
-loki:
-  loki:
-    enabled: true
-
-  promtail:
-    enabled: true
-
-  fluent-bit:
-    enabled: false
-
-  grafana:
-    enabled: false
-
-  prometheus:
-    enabled: false
+# https://github.com/grafana/helm-charts/blob/main/charts/loki-distributed/values.yaml
+# loki-distributed:


### PR DESCRIPTION
We do not need the loki stack w. promtail and other dependencies in this chart as we are moving to Grafana agents

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
