### PR TITLE
ntp: Fix wrong container image version

### DIFF
--- a/charts/ntp/chart/Chart.yaml
+++ b/charts/ntp/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: ntp
-version: 0.1.5
+version: 0.1.6
 description: A helm chart for our ntp-server

--- a/charts/ntp/chart/values.yaml
+++ b/charts/ntp/chart/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/distributed-technologies/helm-charts/ntp
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.4"
+  tag: ""
 
 ntp: {}
   # Override the NTP server (ex: a internal NTP server)


### PR DESCRIPTION
There is no reason for maintaining the version in two places, just let
the chart use the chart version as tag for the image.

Fixes: 8044f04 ("ntp: Add missing capability preventing chronyd from
running")

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
