### PR TITLE
lightvessel: Support supplying values to merge with the values files

### DIFF
--- a/charts/lightvessel/chart/Chart.yaml
+++ b/charts/lightvessel/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lightvessel
 description: A Helm library chart for lightvessel. This chart keeps the template files needed for Yggdrasil and applications.
 type: library
-version: 2.0.3
+version: 2.0.4

--- a/charts/lightvessel/chart/templates/_application.yaml
+++ b/charts/lightvessel/chart/templates/_application.yaml
@@ -42,7 +42,11 @@ spec:
       values: |
         {{- $valuesFilePath := printf "%s/%s/%s" ($configPath | dir) .name .source.valuesFile }}
         {{- $valuesFile := $root.Files.Get $valuesFilePath }}
-{{ tpl $valuesFile $root | indent 8 }}
+        {{- $values := (tpl $valuesFile $root | fromYaml) }}
+        {{- if get ($root.Values.valuesOverride | default dict) .name }}
+          {{- $values := mergeOverwrite $values (get $root.Values.valuesOverride .name) }}
+        {{- end }}
+{{ $values | toYaml | indent 8 }}
   # Destination cluster and namespace to deploy the application
   destination:
     server: {{ $root.Values.destinationServer | default $config.destinationServer | default "https://kubernetes.default.svc" }}


### PR DESCRIPTION
This allow the lightvessel consumer (yggdrasil in our case) to provide
values which is merged with the values files. One use case is injecting
cluster specific secrets when provisioning a development cluster.

This is meant for development and should not be used in production!

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
