### PR TITLE
Add proxy chart for external-dns

### DIFF
--- a/charts/external-dns/chart/.helmignore
+++ b/charts/external-dns/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/external-dns/chart/Chart.yaml
+++ b/charts/external-dns/chart/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: external-dns
+description: A Helm chart for external-dns
+type: application
+version: 0.1.0
+
+dependencies:
+- name: external-dns
+  version: "1.7.1"
+  repository: "https://kubernetes-sigs.github.io/external-dns/"


### PR DESCRIPTION
**Draft until** https://github.com/distributed-technologies/helm-charts/pull/262 is sorted.

"ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with
DNS providers."[1]

We need this to ease access to development clusters, by synchronizing
Services and Ingresses into a internal DNS zone.

[1] https://github.com/kubernetes-sigs/external-dns

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
