### PR TITLE
Feature/add service monitors

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -11,6 +11,7 @@ chart-dirs:
   - charts/cache
   - charts/cni
   - charts/dns-server
+  - charts/exporters
   - charts/git-server
   - charts/grafana
   - charts/grafana-agent
@@ -37,7 +38,7 @@ chart-repos:
   - jaeger=https://jaegertracing.github.io/helm-charts
   - common=https://charts.bitnami.com/bitnami
   - kafka=https://strimzi.io/charts/
-  - kafkaexport=https://prometheus-community.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
   - cp=https://confluentinc.github.io/cp-helm-charts/
   - thanos=https://kubernetes-charts.banzaicloud.com
   - traefik=https://helm.traefik.io/traefik

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -13,6 +13,7 @@ chart-dirs:
   - charts/cni
   - charts/cortex
   - charts/dns-server
+  - charts/exporters
   - charts/fwd-proxy
   - charts/git-server
   - charts/grafana
@@ -46,7 +47,7 @@ chart-repos:
   - jaeger=https://jaegertracing.github.io/helm-charts
   - common=https://charts.bitnami.com/bitnami
   - kafka=https://strimzi.io/charts/
-  - kafkaexport=https://prometheus-community.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
   - cp=https://confluentinc.github.io/cp-helm-charts/
   - thanos=https://kubernetes-charts.banzaicloud.com
   - traefik=https://helm.traefik.io/traefik

--- a/charts/cortex/chart/Chart.yaml
+++ b/charts/cortex/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart for Cortex
 type: application
-version: 0.1.2
+version: 0.1.3
 
 dependencies:
 - name: cortex

--- a/charts/cortex/chart/values.yaml
+++ b/charts/cortex/chart/values.yaml
@@ -16,4 +16,57 @@ bucketClaim:
   storageClassName: ceph-bucket
 
 # https://github.com/cortexproject/cortex-helm-chart/blob/master/values.yaml
-# cortex:
+cortex:
+  alertmanager:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  distributor:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  ingester:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  ruler:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  querier:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  query_frontend:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  table_manager:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  store_gateway:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+  compactor:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        instance: primary

--- a/charts/exporters/chart/.helmignore
+++ b/charts/exporters/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/exporters/chart/Chart.yaml
+++ b/charts/exporters/chart/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: exporters
+description: A Helm chart for our exporters
+type: application
+version: 0.1.0
+
+dependencies:
+  - name: kube-state-metrics
+    version: "4.5.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+  - name: prometheus-node-exporter
+    version: "3.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+  - name: prometheus-kafka-exporter
+    version: "1.1.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus-kafka-exporter.enabled

--- a/charts/exporters/chart/values.yaml
+++ b/charts/exporters/chart/values.yaml
@@ -1,5 +1,5 @@
 kube-state-metrics:
-  ## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+  # set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
   # releaseLabel: false
   prometheus:
     monitor:
@@ -20,4 +20,4 @@ prometheus-kafka-exporter:
     enabled: true
     namespace: ""
     additionalLabels:
-      instance: primary  
+      instance: primary

--- a/charts/exporters/chart/values.yaml
+++ b/charts/exporters/chart/values.yaml
@@ -1,0 +1,23 @@
+kube-state-metrics:
+  ## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+  # releaseLabel: false
+  prometheus:
+    monitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+prometheus-node-exporter:
+  prometheus:
+    monitor:
+      enabled: true
+      additionalLabels:
+        instance: primary
+
+prometheus-kafka-exporter:
+  enabled: true
+  prometheus:
+    enabled: true
+    namespace: ""
+    additionalLabels:
+      instance: primary  

--- a/charts/loki/chart/Chart.yaml
+++ b/charts/loki/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: A Helm umbrella chart for Loki
 type: application
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
 - name: loki-distributed

--- a/charts/loki/chart/values.yaml
+++ b/charts/loki/chart/values.yaml
@@ -1,2 +1,6 @@
 # https://github.com/grafana/helm-charts/blob/main/charts/loki-distributed/values.yaml
-# loki-distributed:
+loki-distributed:
+  serviceMonitor:
+    enabled: true
+    labels:
+      instance: primary

--- a/charts/rook/chart/Chart.yaml
+++ b/charts/rook/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rook
 description: A Helm chart for Rook
 type: application
-version: 0.1.4
+version: 0.1.5
 
 dependencies:
   - name: rook-ceph

--- a/charts/rook/chart/templates/service-monitor.yaml
+++ b/charts/rook/chart/templates/service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rook-ceph-mgr
+  labels:
+    release: prometheus
+    ceph_cluster: rook-ceph
+spec:
+  namespaceSelector:
+    matchNames:
+      - rook-ceph
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr
+      rook_cluster: rook-ceph
+  endpoints:
+  - port: http-metrics
+    path: /metrics
+    interval: 5s

--- a/charts/tempo-distributed/chart/Chart.yaml
+++ b/charts/tempo-distributed/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: A Helm chart for tempo-distributed
 type: application
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
 - name: tempo-distributed

--- a/charts/tempo-distributed/chart/values.yaml
+++ b/charts/tempo-distributed/chart/values.yaml
@@ -10,4 +10,8 @@ bucketClaim:
   storageClassName: ceph-bucket
 
 # https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/values.yaml
-# tempo-distibuted:
+tempo-distibuted:
+  serviceMonitor:
+    enabled: true
+    labels:
+      instance: primary


### PR DESCRIPTION
**Description of your changes:**
- I have added a new helm chart called exporters in which the kafka exporter, node exporter and kubernetes state exporter are included. 
- I have added the rook-ceph service monitor to the rook chart
- I have added the new exporters chart to our ct-lint and ct-install configs 
- I have removed service monitor values from yggdrasil and added them into the values files here for loki, cortex and tempo

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
