### PR TITLE
Feature/kafka default log retention

### DIFF
--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.2
+version: 1.1.3
 
 dependencies:
 - name: strimzi-kafka-operator

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -44,12 +44,14 @@ spec:
       superUsers: # TODO add authentication
         - ANONYMOUS
     config: 
-      auto.create.topics.enable: {{ .Values.cluster.kafka.autoCreateTopic }}
-      offsets.topic.replication.factor: {{ .Values.cluster.kafka.offsetTopicReplicationFactor }}
-      transaction.state.log.replication.factor: {{ .Values.cluster.kafka.transactionStateLog.replicationFactor }}
-      transaction.state.log.min.isr: {{ .Values.cluster.kafka.transactionStateLog.minimumInSyncReplicas }}
       log.message.format.version: {{ .Values.cluster.kafka.version }}
       inter.broker.protocol.version: {{ .Values.cluster.kafka.version }}
+    {{- with .Values.cluster.kafka.config }}
+      auto.create.topics.enable: {{ .autoCreateTopicEnable }}
+      offsets.topic.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .offsetsTopicReplicationFactor) }}
+      transaction.state.log.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .transactionStateLogReplicationFactor ) }}
+      transaction.state.log.min.isr: {{ min $.Values.cluster.kafka.replicas (default 2 .transactionStateLogMinIsr) }}
+    {{- end }}
       ssl.cipher.suites: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" 
       ssl.enabled.protocols: "TLSv1.2"
       ssl.protocol: "TLSv1.2"

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -48,6 +48,8 @@ spec:
       inter.broker.protocol.version: {{ .Values.cluster.kafka.version }}
     {{- with .Values.cluster.kafka.config }}
       auto.create.topics.enable: {{ .autoCreateTopicEnable }}
+      log.retention.hours: {{ .logRetentionHours }}
+      log.roll.hours: {{ .logRollHours }}
       offsets.topic.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .offsetsTopicReplicationFactor) }}
       transaction.state.log.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .transactionStateLogReplicationFactor ) }}
       transaction.state.log.min.isr: {{ min $.Values.cluster.kafka.replicas (default 2 .transactionStateLogMinIsr) }}

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -48,8 +48,8 @@ spec:
       inter.broker.protocol.version: {{ .Values.cluster.kafka.version }}
     {{- with .Values.cluster.kafka.config }}
       auto.create.topics.enable: {{ .autoCreateTopicEnable }}
-      log.retention.hours: {{ .logRetentionHours }}
-      log.roll.hours: {{ .logRollHours }}
+      log.retention.hours: {{ default 168 .logRetentionHours }}
+      log.roll.hours: {{ default 168 .logRollHours }}
       offsets.topic.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .offsetsTopicReplicationFactor) }}
       transaction.state.log.replication.factor: {{ min $.Values.cluster.kafka.replicas (default 3 .transactionStateLogReplicationFactor ) }}
       transaction.state.log.min.isr: {{ min $.Values.cluster.kafka.replicas (default 2 .transactionStateLogMinIsr) }}

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -18,6 +18,9 @@ cluster:
     config:
       # If a topic does not exist, create it if someone writes to it.
       autoCreateTopicEnable: "false"
+      # Default is 7 days which is more than we need, reducing saves storage.
+      logRetentionHours: 48
+      logRollHours: 24
       # offsetsTopicReplicationFactor: 3
       # transactionStateLogReplicationFactor: 3
       # transactionStateLogMinIsr: 2

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -13,12 +13,14 @@ cluster:
       class: standard
       size: 500Mi
     replicas: 1
-    # If a topic does not exist, create it if someone writes to it.
-    autoCreateTopic: "false"
-    offsetTopicReplicationFactor: 1
-    transactionStateLog:
-      replicationFactor: 1
-      minimumInSyncReplicas: 1
+    # A subset of the broker configuration can be set here
+    # see https://kafka.apache.org/documentation/#brokerconfigs
+    config:
+      # If a topic does not exist, create it if someone writes to it.
+      autoCreateTopicEnable: "false"
+      # offsetsTopicReplicationFactor: 3
+      # transactionStateLogReplicationFactor: 3
+      # transactionStateLogMinIsr: 2
     # https://strimzi.io/docs/operators/in-development/using.html#type-GenericKafkaListener-reference
     listeners:
       - name: plain

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -18,9 +18,9 @@ cluster:
     config:
       # If a topic does not exist, create it if someone writes to it.
       autoCreateTopicEnable: "false"
-      # Default is 7 days which is more than we need, reducing saves storage.
-      logRetentionHours: 48
-      logRollHours: 24
+      # The following configurations can be set, when not they use the default
+      # logRetentionHours: 168
+      # logRollHours: 168
       # offsetsTopicReplicationFactor: 3
       # transactionStateLogReplicationFactor: 3
       # transactionStateLogMinIsr: 2


### PR DESCRIPTION
We will be adding more options to the broker configuration. This
keeps our values file similar to the layout of the kafka broker
configuration making it easier to understand.

With the refactor, we apply defaults to the replication factors,
while keeping the requirement that #replicas <= #brokers intact.
This eliminates some configuration errors in testing senarios
where #brokers is set to 1.

Many small topics use up all the available storage in the brokers. In
our testing setups the PVC for the broker is only 5GB and we cannot
afford the default 7 day retention and rollover with our current load.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
