### PR TITLE
Add exporters chart

### DIFF
--- a/charts/exporters/README.md
+++ b/charts/exporters/README.md
@@ -1,0 +1,6 @@
+# Exporters chart
+
+This is the helm chart for our exporter dependencies. The dependencies must be enabled individually in the values.yaml file.
+
+### Service monitors
+To enable service monitors from the dependencies, look at the examples in the values.yaml file.

--- a/charts/exporters/chart/.helmignore
+++ b/charts/exporters/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/exporters/chart/Chart.yaml
+++ b/charts/exporters/chart/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: exporters
+description: A Helm chart for our exporters
+type: application
+version: 0.1.0
+
+dependencies:
+  - name: kube-state-metrics
+    version: "4.5.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: kube-state-metrics.enabled
+  - name: prometheus-node-exporter
+    version: "3.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus-node-exporter.enabled
+  - name: prometheus-kafka-exporter
+    version: "1.1.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus-kafka-exporter.enabled

--- a/charts/exporters/chart/values.yaml
+++ b/charts/exporters/chart/values.yaml
@@ -1,0 +1,23 @@
+# kube-state-metrics:
+#   enabled: true
+#   prometheus:
+#     monitor:
+#       enabled: true
+#       additionalLabels:
+#         instance: primary
+
+# prometheus-node-exporter:
+#   enabled: true
+#   prometheus:
+#     monitor:
+#       enabled: true
+#       additionalLabels:
+#         instance: primary
+
+# prometheus-kafka-exporter:
+#   enabled: true
+#   prometheus:
+#     enabled: true
+#     namespace: ""
+#     additionalLabels:
+#       instance: primary


### PR DESCRIPTION
**Description of your changes:**
Added functionality to get kubernetes state metrics, node metrics and kafka metrics.
The charts are disabled by default and will have to be enabled in Yggdrasil. 


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
