### PR TITLE
rook: Drop out-of-date image tag override

### DIFF
--- a/charts/rook/chart/Chart.yaml
+++ b/charts/rook/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rook
 description: A Helm chart for Rook
 type: application
-version: 0.1.4
+version: 0.1.5
 
 dependencies:
   - name: rook-ceph

--- a/charts/rook/chart/values.yaml
+++ b/charts/rook/chart/values.yaml
@@ -1,3 +1,1 @@
-rook-ceph:
-  image:
-    tag: v1.7.2
+rook-ceph: {}


### PR DESCRIPTION
It is unclear why this was added in[1], but we should use the image tag
specified in the upstream chart.

[1] https://github.com/distributed-technologies/services-rook/pull/4

Fixes: 98db9e9 ("argo, ceph, grafana, rook, traefik: bumped to newest versions")

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
