### PR TITLE
nidhogg: Add switch for enabling the CNI's serviceMonitors

### DIFF
--- a/charts/nidhogg/chart/Chart.lock
+++ b/charts/nidhogg/chart/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: lb-proxy
   repository: https://distributed-technologies.github.io/helm-charts/
   version: 0.1.0
-digest: sha256:c3058e997e797bc6b34c556667305c7bb58f31a5e1ce00ade7804716a70dbe1a
-generated: "2022-02-21T15:13:13.934454327Z"
+digest: sha256:c27befc40e848330f56535d2c6e88a741a6226ffd63212ba1b254a01de781296
+generated: "2022-03-15T08:55:07.555062608+01:00"

--- a/charts/nidhogg/chart/Chart.yaml
+++ b/charts/nidhogg/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: nidhogg
 description: A chart that deploys nidhogg.
-version: 1.0.17
+version: 1.0.18
 
 dependencies:
   - name: argo-cd-proxy-chart
@@ -11,7 +11,7 @@ dependencies:
   - name: cni
     version: 1.0.0
     repository: "https://distributed-technologies.github.io/helm-charts/"
-    condition: 'installCNI'
+    condition: 'cni.enabled'
   - name: lb-proxy
     version: "0.1.0"
     repository: "https://distributed-technologies.github.io/helm-charts/"

--- a/charts/nidhogg/chart/templates/nidhogg.yaml
+++ b/charts/nidhogg/chart/templates/nidhogg.yaml
@@ -21,6 +21,30 @@ spec:
       version: v3
       values: |
         nidhogg:
+          {{- if .Values.cni.serviceMonitor.enabled }}
+          cni:
+            cilium:
+              hubble:
+                metrics:
+                  enabled: [dns,drop,tcp,flow,icmp,http]
+                  serviceMonitor:
+                    enabled: true
+                    labels:
+                      instance: primary
+              prometheus:
+                enabled: true
+                serviceMonitor:
+                  enabled: true
+                  labels:
+                    instance: primary
+              operator:
+                prometheus:
+                  enabled: true
+                  serviceMonitor:
+                    enabled: true
+                    labels:
+                      instance: primary
+          {{- end }}
           yggdrasil:
             {{- toYaml .Values.yggdrasil | nindent 12 }}
           {{- with (index .Values "lb-proxy") }}

--- a/charts/nidhogg/chart/values.yaml
+++ b/charts/nidhogg/chart/values.yaml
@@ -2,7 +2,11 @@ yggdrasil:
   repoURL: "https://github.com/distributed-technologies/yggdrasil.git"
   targetRevision: "main"
 
-installCNI: true
+cni:
+  enabled: true
+  serviceMonitor:
+    enabled: false
+
 monitorNidhogg: true
 
 lb-proxy:


### PR DESCRIPTION
A single switch is added, so they can easily be enabled in yggdrasil.

**Description of your changes:**

yggdrasil PR: https://github.com/distributed-technologies/helm-charts/pull/285

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
