### PR TITLE
Add cAdvisor monitor to exporters

### DIFF
--- a/charts/exporters/chart/Chart.yaml
+++ b/charts/exporters/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: exporters
 description: A Helm chart for our exporters
 type: application
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   - name: kube-state-metrics

--- a/charts/exporters/chart/templates/cAdvisor-sm.yaml
+++ b/charts/exporters/chart/templates/cAdvisor-sm.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.cadvisor }} {{/* <-- Check if the fiels exists */}}
+{{- if .Values.cadvisor.monitor }} {{/* <-- Check if the fiels exists */}}
+{{- if .Values.cadvisor.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+  {{- if .Values.cadvisor.monitor.additionalLabels }}
+    {{- toYaml .Values.cadvisor.monitor.additionalLabels | nindent 4 }}
+  {{- end }}
+  name: cadvisor-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    honorTimestamps: false
+    interval: 60s
+    metricRelabelings:
+    - action: keep
+      regex: kubelet_cgroup_manager_duration_seconds_count|go_goroutines|kubelet_pod_start_duration_seconds_count|kubelet_runtime_operations_total|kubelet_pleg_relist_duration_seconds_bucket|volume_manager_total_volumes|kubelet_volume_stats_capacity_bytes|container_cpu_usage_seconds_total|container_network_transmit_bytes_total|kubelet_runtime_operations_errors_total|container_network_receive_bytes_total|container_memory_swap|container_network_receive_packets_total|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|kubelet_running_pod_count|node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate|container_memory_working_set_bytes|storage_operation_errors_total|kubelet_pleg_relist_duration_seconds_count|kubelet_running_pods|rest_client_request_duration_seconds_bucket|process_resident_memory_bytes|storage_operation_duration_seconds_count|kubelet_running_containers|kubelet_runtime_operations_duration_seconds_bucket|kubelet_node_config_error|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_running_container_count|kubelet_volume_stats_available_bytes|kubelet_volume_stats_inodes|container_memory_rss|kubelet_pod_worker_duration_seconds_count|kubelet_node_name|kubelet_pleg_relist_interval_seconds_bucket|container_network_receive_packets_dropped_total|kubelet_pod_worker_duration_seconds_bucket|container_start_time_seconds|container_network_transmit_packets_dropped_total|process_cpu_seconds_total|storage_operation_duration_seconds_bucket|container_memory_cache|container_network_transmit_packets_total|kubelet_volume_stats_inodes_used|up|rest_client_requests_total
+      sourceLabels:
+      - __name__
+    - action: replace
+      targetLabel: job
+      replacement: integrations/kubernetes/cadvisor
+    path: /metrics/cadvisor
+    port: https-metrics
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/exporters/chart/values.yaml
+++ b/charts/exporters/chart/values.yaml
@@ -1,3 +1,9 @@
+# cadvisor:
+#   monitor:
+#     enabled: true
+#     additionalLabels:
+#       instance: primary
+
 # kube-state-metrics:
 #   enabled: true
 #   prometheus:


### PR DESCRIPTION
By adding the cAdvisor monitor back, we will be able to collect metrics on the container layer.

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
