### PR TITLE
exporters: Change namespace to kube-system

### DIFF
--- a/charts/exporters/chart/Chart.yaml
+++ b/charts/exporters/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: exporters
 description: A Helm chart for our exporters
 type: application
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   - name: kube-state-metrics

--- a/charts/exporters/chart/templates/cAdvisor-sm.yaml
+++ b/charts/exporters/chart/templates/cAdvisor-sm.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cadvisor }} {{/* <-- Check if the fiels exists */}}
-{{- if .Values.cadvisor.monitor }} {{/* <-- Check if the fiels exists */}}
+{{- if .Values.cadvisor }} {{/* <-- Check if the field exists */}}
+{{- if .Values.cadvisor.monitor }} {{/* <-- Check if the field exists */}}
 {{- if .Values.cadvisor.monitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -34,7 +34,7 @@ spec:
       insecureSkipVerify: true
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - kube-system
   selector:
     matchLabels:
       app.kubernetes.io/name: kubelet


### PR DESCRIPTION
The namespace was changed to kube-system from {{ .Release.namespace }}
since the kubelet resides in the kube-system namespace

Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
