### PR TITLE
Enable exporters in kube-prometheus-stack

### DIFF
--- a/charts/prometheus/chart/Chart.yaml
+++ b/charts/prometheus/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 description: A Helm chart for Prometheus
 type: application
-version: 0.1.4
+version: 0.1.6
 
 # In version 33.1.0 there are some problems with a too big CRD from the operator, see https://github.com/prometheus-operator/prometheus-operator/issues/4439#issue-1073133029
 # For now I will not update to the latest version.

--- a/charts/prometheus/chart/values.yaml
+++ b/charts/prometheus/chart/values.yaml
@@ -6,30 +6,11 @@ kube-prometheus-stack:
   alertmanager:
     enable: false
 
-  kubeStateMetrics:
-    # This is set to false since we're deploying our own instance - using this condition https://github.com/prometheus-community/helm-charts/blob/90930fcb26e41156892a4457133b38a238469ee8/charts/kube-prometheus-stack/Chart.yaml#L43-L46
-    enabled: false
-
-  nodeExporter:
-    # This is set to false since we're deploying our own instance - using this condition https://github.com/prometheus-community/helm-charts/blob/90930fcb26e41156892a4457133b38a238469ee8/charts/kube-prometheus-stack/Chart.yaml#L47-L50
-    enabled: false
-
   prometheus:
     enabled: true
 
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
     prometheusSpec:
-      serviceMonitorSelector:
-        matchLabels:
-          instance: primary
-
-      podMonitorSelector:
-        matchLabels:
-          instance: primary
-
-      probeSelector:
-        matchLabels:
-          instance: primary
 
       # This is set from 10d to 2h because, Cause we should remote-write to cortex, and shouldn't need a large retention on prometheus itself
       retention: 2h


### PR DESCRIPTION
Some of the Grafana dashboards that we're using is build using [1]
these charts are build for the kube-prometheus-stack, for that reason
I have enabled the exporters in the kube-promehteus-stack again,

I have also removed the label requirement, since I see no reason to have them

The exporters helm chart has them disabled by default.

[1] https://github.com/kubernetes-monitoring/kubernetes-mixin

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
