### PR TITLE
lightvessel: Allow LimitRange for namespaces

### DIFF
--- a/charts/lightvessel/chart/Chart.yaml
+++ b/charts/lightvessel/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lightvessel
 description: A Helm library chart for lightvessel. This chart keeps the template files needed for Yggdrasil and applications.
 type: library
-version: 2.0.4
+version: 2.0.5

--- a/charts/lightvessel/chart/templates/_limitRange.yaml
+++ b/charts/lightvessel/chart/templates/_limitRange.yaml
@@ -1,0 +1,24 @@
+{{- define "limitRange" }}
+  {{- $root := . }}
+  {{- range $limitRangePath, $_ := .Files.Glob "**/**/limit-range.yaml" }}
+    {{- $configPath := printf "%s/config.yaml" ($limitRangePath | dir) }}
+    {{- $config := $root.Files.Get $configPath | fromYaml }}
+    {{- $appEnabledInConfig := 0 }}
+    {{- range $config.apps }}
+      {{- if get $root.Values.applications .name }}
+        {{- $appEnabledInConfig = 1 }}
+      {{- end }}
+    {{- end }}
+    {{- if $appEnabledInConfig }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ template "helper.name" (dict "context" $root "name" $config.name ) }}-limit-range
+  namespace: {{ $config.namespace }}
+spec:
+{{- $limitRange := $root.Files.Get $limitRangePath }}
+{{ tpl $limitRange $root | indent 2 }}
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Limit ranges are needed to set default resource requests and limits for
some namespaces. Preferably, resource limits are configured on each
pod, however, some helm charts deploy resources without limits and
without an option to specify limits.

This is the case for the rook-ceph-cluster chart.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
