### PR TITLE
Add resource limits

### DIFF
--- a/charts/ceph/chart/Chart.yaml
+++ b/charts/ceph/chart/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 description: Manages a single Ceph cluster namespace for Rook
 name: rook-ceph-cluster
-version: 0.1.7
+version: 0.1.8
 
 dependencies:
   - name: rook-ceph-cluster
-    version: "1.8.5"
+    version: "1.9.3"
     repository: "https://charts.rook.io/release"

--- a/charts/ceph/chart/values.yaml
+++ b/charts/ceph/chart/values.yaml
@@ -1,1 +1,1 @@
-# This is a values file
+# this is a values file

--- a/charts/cortex/chart/Chart.yaml
+++ b/charts/cortex/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart for Cortex
 type: application
-version: 0.1.3
+version: 0.1.4
 
 dependencies:
 - name: cortex

--- a/charts/cortex/chart/values.yaml
+++ b/charts/cortex/chart/values.yaml
@@ -20,3 +20,83 @@ cortex:
   config:
     limits:
       compactor_blocks_retention_period: 336h
+  alertmanager:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  distributor:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  ingester:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+  ruler:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  querier:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  query_frontend:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  table_manager:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  nginx:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  store_gateway:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+  compactor:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi

--- a/charts/grafana/chart/Chart.yaml
+++ b/charts/grafana/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana
 description: A Helm umbrella chart for Grafana
 type: application
-version: 0.1.13
+version: 0.1.14
 
 dependencies:
   - name: grafana

--- a/charts/grafana/chart/values.yaml
+++ b/charts/grafana/chart/values.yaml
@@ -1,1 +1,16 @@
-# This is a values file
+grafana:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 2000m
+      memory: 6Gi
+  sidecar:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi

--- a/charts/prometheus/chart/Chart.yaml
+++ b/charts/prometheus/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 description: A Helm chart for Prometheus
 type: application
-version: 0.1.6
+version: 0.1.7
 
 # In version 33.1.0 there are some problems with a too big CRD from the operator, see https://github.com/prometheus-operator/prometheus-operator/issues/4439#issue-1073133029
 # For now I will not update to the latest version.

--- a/charts/prometheus/chart/values.yaml
+++ b/charts/prometheus/chart/values.yaml
@@ -17,3 +17,43 @@ kube-prometheus-stack:
 
       remoteWrite:
         - url: http://cortex-distributor:8080/api/v1/push
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 500Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi
+
+  prometheusOperator:
+    admissionWebhooks:
+      patch:
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
+
+  kube-state-metrics:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  prometheus-node-exporter:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 30Mi
+      limits:
+        cpu: 200m
+        memory: 50Mi

--- a/charts/prometheus/chart/values.yaml
+++ b/charts/prometheus/chart/values.yaml
@@ -4,7 +4,7 @@ kube-prometheus-stack:
 
   # Disabled since we're using cortexs
   alertmanager:
-    enable: false
+    enabled: false
 
   prometheus:
     enabled: true

--- a/charts/rook/chart/Chart.yaml
+++ b/charts/rook/chart/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: rook
 description: A Helm chart for Rook
 type: application
-version: 0.1.5
+version: 0.1.6
 
 dependencies:
   - name: rook-ceph
-    version: "1.8.5"
+    version: "1.9.3"
     repository: "https://charts.rook.io/release"


### PR DESCRIPTION
In yggdrasil 3.0.1 Resource Quotas were added to the namespaces for: rook-ceph, monitoring, and networking. That broke the current setup, since none of the resources deployed to those namespaces had any resource limits set. This PR fixes that.

We add resource limits to multiple helm charts.



Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
