### PR TITLE
squid: Fix wrong chart name

### DIFF
--- a/charts/squid/chart/Chart.yaml
+++ b/charts/squid/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
-name: chart
+name: squid
 description: A Helm chart for Squid
 version: 0.1.0


### PR DESCRIPTION
Fixes: 723519c ("Add squid service")

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
