### PR TITLE
Add Tenant-base helm chart

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -10,6 +10,7 @@ chart-dirs:
   - charts/ntp
   - charts/vault
   - charts/squid
+  - charts/tenant-base
 chart-repos:
   - kafka=https://strimzi.io/charts/
   - kafkaexport=https://prometheus-community.github.io/helm-charts

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -11,6 +11,7 @@ chart-dirs:
   - charts/ntp
   - charts/vault
   - charts/squid
+  - charts/tenant-base
 chart-repos:
   - kafka=https://strimzi.io/charts/
   - kafkaexport=https://prometheus-community.github.io/helm-charts

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -36,11 +36,12 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
-        if: steps.list-changed.outputs.changed == 'true'
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.7.0
         with:
-          config: ci/kind.yaml
+          minikube version: 'v1.27.1'
+          kubernetes version: 'v1.25.0'
+          github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml --upgrade --helm-extra-args "--timeout 7200s"

--- a/charts/tenant-base/README.md
+++ b/charts/tenant-base/README.md
@@ -1,0 +1,3 @@
+# Tenant-base
+
+A basic helm chart that out tenants can use.

--- a/charts/tenant-base/chart/.helmignore
+++ b/charts/tenant-base/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: tenant-base
+description: A basic Helm chart for tenants
+type: application
+version: 0.1.0

--- a/charts/tenant-base/chart/templates/_helpers.tpl
+++ b/charts/tenant-base/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          {{- range .Values.ports }}
+            - name: {{ .podPortName }}
+              containerPort: {{ .podPort }}
+              protocol: {{ .protocol }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 8 }}
+{{- end }}
+      volumes:
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if $.Values.extraContainerVolumes }}
+{{ tpl (toYaml $.Values.extraContainerVolumes) $ | indent 8 }}
+{{- end }}

--- a/charts/tenant-base/chart/templates/service.yaml
+++ b/charts/tenant-base/chart/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+{{- range .Values.ports }}
+    - port: {{ .servicePort }}
+      name: {{ .servicePortName }}
+      targetPort: {{ .podPortName }}
+      protocol: {{ .protocol }}
+{{- end }}
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -1,0 +1,67 @@
+image:
+  repository: ghcr.io/stefanprodan/podinfo
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 6.2.1
+
+imagePullSecrets: []
+
+replicaCount: 1
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 9898
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 9898
+
+volumes: []
+#  - name: cache-volume
+#    emptyDir: {}
+
+volumeMounts: []
+#  - mountPath: /cache
+#    name: cache-volume
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Enable an Specify container in extraContainers.
+extraContainers: ""
+# extraContainers: |
+#   - name: extra-container
+#     image: stefanprodan/podinfo:latest
+#     ports:
+#       - name: http
+#         containerPort: 80
+
+## Volumes that can be used in init containers that will not be mounted to deployment pods
+extraContainerVolumes: []
+  # - name: empty-dir-volume
+  #   emptyDir: {}
+
+service:
+  type: ClusterIP
+
+ports:
+  - podPortName: http
+    podPort: 9898
+    servicePortName: http
+    servicePort: 80
+    protocol: TCP
+
+# TODO extend with Kafka topics
+
+# TODO extend with external Secrets


### PR DESCRIPTION
We want a basic helm chart that we can package with out tenant repo, that makes it easy for the tenants to set the values needed for their service to run.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
