### PR TITLE
tenant-base: Add support for external secrets

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -42,6 +42,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- with .Values.secrets }}
+          envFrom:
+            {{- range . }}
+            - secretRef:
+                name: {{ include "chart.fullname" $ }}-{{ .name }}
+            {{- end }}
+          {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 8 }}
 {{- end }}

--- a/charts/tenant-base/chart/templates/externalsecret.yaml
+++ b/charts/tenant-base/chart/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+{{- range .Values.secrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "chart.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  refreshInterval: "5m"
+  secretStoreRef:
+    name: {{ $.Values.secretStore.name }}
+    kind: {{ $.Values.secretStore.kind }}
+  target:
+    name: {{ include "chart.fullname" $ }}-{{ .name }}
+  dataFrom:
+  - extract:
+      key: {{ .key }}
+{{- end }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -64,4 +64,10 @@ ports:
 
 # TODO extend with Kafka topics
 
-# TODO extend with external Secrets
+secretStore:
+  name: default
+  kind: ClusterSecretStore
+
+secrets: []
+#  - name: token
+#    key: secret/tenant-foobar/token


### PR DESCRIPTION
This adds support for external secrets, which is the way we have decided
to handle secrets. The user must provide a name for the external secret
and the key (eg.: path in Vault). The keys in the secret are set as
environment variables in the container.

The user can set secretStore, but this is expected to be handled by a
Kustomization patch.

---

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
