### PR TITLE
Add to the halmchart that tenants can create kafka topics

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.3.0
+version: 0.4.0

--- a/charts/tenant-base/chart/templates/kafkatopic.yaml
+++ b/charts/tenant-base/chart/templates/kafkatopic.yaml
@@ -1,0 +1,18 @@
+{{- range .Values.kafkaTopics }}
+# https://strimzi.io/docs/operators/latest/configuring.html#type-KafkaTopic-reference
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{ .name }}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec: 
+  topicName: {{ .name }}
+  partitions: {{ .partitions }}
+  replicas: {{  .replicas }}
+  config: 
+    # https://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: {{ .retention.ms | default  604800000 }} # 7 days
+    retention.bytes: {{ .retention.bytes | default -1 }}
+---
+{{- end }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -110,4 +110,14 @@ persistentVolumeClaims:
 secretStore:
   name: default
   kind: ClusterSecretStore
-# TODO extend with Kafka topics
+
+# List of Kafka topics to create.
+# Note: The example shows the only supported configuration fields of a Kafka topic with the default values.
+# If you need to do more advanced configuration of a Kafka topics, please contact the maintainers, so they can add support for the requested configuration field.
+kafkaTopics: []
+#  - name: "example-topic"  #(required)
+#    replicas: 3
+#    partitions: 1
+#    retention:
+#      ms: 604800000
+#      bytes: -1


### PR DESCRIPTION
**Description of your changes:**
Add to the helm chart that tenants can create Kafka topics and do some limited configuration

Documentation will come in a later task as it depends on the format in another user-story. 
Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
