### PR TITLE
ci: Fix broken "Install Helm" step

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -11,9 +11,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
-
       - name: Set up python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,9 +13,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-
       - name: Add dependency chart repos
         run: |
           helm repo add helmcharts https://distributed-technologies.github.io/helm-charts/


### PR DESCRIPTION
The GitHub Action broke[1] and the runner image already ships with helm,
so just use the preinstalled version.

[1] https://github.com/Azure/setup-helm/issues/97
[2] https://github.com/actions/runner-images/blob/1250493b2fdfdaf09244c1c87798ec1e65743212/images/linux/Ubuntu2004-Readme.md#package-management