### PR TITLE
renovate: Bump chart version when updating dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
   "schedule": [
     "after 08:00 every weekday",
     "before 15:00 every weekday"
-  ]
+  ],
+  "bumpVersion": "patch"
 }


### PR DESCRIPTION
Our homebrewed dependency updater bumped the patch version, so configure Renovate to do the same.

Fixes: 5f4e9d5 ("Replace homebrewed dependency updater with Renovate")

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
