### PR TITLE
tenant-base: Referenced acr-token in imagePullSecret

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -18,8 +18,7 @@ deployments:
 
     # The name of the secret that contains the credentials for private image repositories.
     imagePullSecrets:
-      []
-      # - name: foobar-creds
+      - name: acr-token
 
     # The amount of replicas wanted of this container
     replicaCount: 3


### PR DESCRIPTION
**Description of your changes:**
I have referenced the acr-token imagePullSecret in the values file of the tenant-base helm chart. This is done because we from now on will deploy a secret containing our acr-token to each tenant namespace so that they can pull container images from our ACR. 

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
