### PR TITLE
Tenant-base: Change from list to map

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/tenant-base/chart/templates/_helpers.tpl
+++ b/charts/tenant-base/chart/templates/_helpers.tpl
@@ -72,5 +72,5 @@ topologySpreadConstraints:
     labelSelector:
       matchLabels:
         {{- include "chart.selectorLabels" .root | nindent 8 }}
-        app.kubernetes.io/app: {{ .values.name }}
+        app.kubernetes.io/app: {{ .name }}
 {{- end }}

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -1,9 +1,9 @@
-{{- range .Values.deployments }}
+{{- range $name, $val := .Values.deployments }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "chart.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/app: {{ .name }}
+      app.kubernetes.io/app: {{ $name }}
   template:
     metadata:
       {{- with .podAnnotations }}
@@ -20,15 +20,15 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.selectorLabels" $ | nindent 8 }}
-        app.kubernetes.io/app: {{ .name }}
+        app.kubernetes.io/app: {{ $name }}
     spec:
-      {{- include "chart.topologySpreadConstrains" (dict "root" $ "values" .) | nindent 6 }}
+      {{- include "chart.topologySpreadConstrains" (dict "root" $ "values" $val "name" $name) | nindent 6 }}
       {{- with .imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ .name }}
+        - name: {{ $name }}
           securityContext:
             {{- toYaml .securityContext | nindent 12 }}
           image: {{ printf "%s:%s" .image.repository .image.tag }}
@@ -51,7 +51,7 @@ spec:
           envFrom:
             {{- range . }}
             - secretRef:
-                name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+                name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
             {{- end }}
           {{- end }}
       volumes:

--- a/charts/tenant-base/chart/templates/externalsecret.yaml
+++ b/charts/tenant-base/chart/templates/externalsecret.yaml
@@ -1,10 +1,10 @@
-{{- range .Values.deployments }}
+{{- range $name, $val := .Values.deployments }}
 {{- range .secrets }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
@@ -13,7 +13,7 @@ spec:
     name: {{ $.Values.secretStore.name }}
     kind: {{ $.Values.secretStore.kind }}
   target:
-    name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+    name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   dataFrom:
   - extract:
       key: {{ .key }}

--- a/charts/tenant-base/chart/templates/networkpolicy.yaml
+++ b/charts/tenant-base/chart/templates/networkpolicy.yaml
@@ -1,17 +1,17 @@
-{{- range .Values.deployments }}
+{{- range $name, $val := .Values.deployments }}
 {{- if .networkPolicy }}
 {{- if or .networkPolicy.ingress .networkPolicy.egress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
       {{- include "chart.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/app: {{ .name }}
+      app.kubernetes.io/app: {{ $name }}
   policyTypes:
     {{- if .networkPolicy.ingress }}
     - Ingress

--- a/charts/tenant-base/chart/templates/service.yaml
+++ b/charts/tenant-base/chart/templates/service.yaml
@@ -1,9 +1,9 @@
-{{- range .Values.deployments }}
+{{- range $name, $val := .Values.deployments }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
@@ -16,5 +16,5 @@ spec:
 {{- end }}
   selector:
     {{- include "chart.selectorLabels" $ | nindent 4 }}
-    app.kubernetes.io/app: {{ .name }}
+    app.kubernetes.io/app: {{ $name }}
 {{ end -}}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: foobar
 # A list of deployments, this allows for multiple deployments in the same chart.
 deployments:
   # Name of the deployments - this is appended on the deployment and service name.
-  - name: podinfo
+  podinfo:
     image:
       # The repository containing the image
       repository: ghcr.io/stefanprodan/podinfo

--- a/charts/tenant-base/docs/deployment.md
+++ b/charts/tenant-base/docs/deployment.md
@@ -4,12 +4,21 @@ A deployment is used to describe how we want to deploy one or more containers in
 
 > [kubernetes.io#Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 
-The [deployments list](../chart/values.yaml#l5) is used to describe one or more deployments that we want to run on kubernetes, to describe a deployment we need to set some values:
+The [deployments](../chart/values.yaml#l5) is used to describe one or more deployments that we want to run on kubernetes, to describe a deployment we need to set some values:
 
-## name
+A deployment is started by making a key in the deployments object, this key can be anything and will be used as part of the name for the deployment.
+
+```yaml
+deployments:
+  foo: #<-- this will be the name of the deployments
+    image: foo-bar
+    ...
+```
 
 [`name`](../chart/values.yaml#l7) is the name of the deployment, this should be descriptive of what this deployment deploys.
 This name is also being used to in the name of the pods, like we saw in [fullnameOverride](../README.md#fullenameoverride).
+
+Name is also the key of the deployment object.
 
 If we set the name of the deployment to `foo` the name of the pods now contains foo as part of their name.
 
@@ -18,6 +27,8 @@ podinfo-tenant-base-foo-57c9487678-dncs8
 podinfo-tenant-base-foo-57c9487678-kg9j7
 podinfo-tenant-base-foo-57c9487678-shlmj
 ```
+
+This value of they key will then contain the rest of the deployment configuration.
 
 ## image
 
@@ -140,6 +151,7 @@ This list also adds the secret to the pod as environment variables.
 Please also read Kubernetes documentation on [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
 
 Example:
+
 ```yaml
 deployments:
   - name: podinfo


### PR DESCRIPTION
**Description of your changes:**

Changed `deployments` from a list to a map, this is because merging lists often causes complete overrides if not done correctly, using maps merging is a lot simpler.

Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
