### PR TITLE
tenant-base: Add Kafka communication to the tenant-base helm chart

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -1,5 +1,6 @@
+---
 apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.4.4
+version: 0.5.0

--- a/charts/tenant-base/chart/templates/configmap-kafka-topic.yaml
+++ b/charts/tenant-base/chart/templates/configmap-kafka-topic.yaml
@@ -1,0 +1,22 @@
+{{- range .Values.kafkaTopics.access }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafkatopic--{{ .name }}--accessed-by--{{.applicationName}}
+  labels: 
+    kyverno.digest/configmap: "generate-cilium-network-policy-for-kafka-topic"
+  annotations:
+    kubernetes.io/description: "ConfigMap digested by Kyverno to give the application {{ .applicationName }} in the {{ .namespace }} access to the KafkaTopic {{ .name }}"
+data:
+  config: |
+    {
+      "application_namespace": "{{ .namespace }}",
+      "application_name": "{{ .applicationName }}",
+      "kafka_topic_name": "{{ .name }}",
+      "policy_rules": {
+        "produce": {{ .produce }},
+        "consume": {{ .consume }}
+      }
+    }
+{{ end -}}

--- a/charts/tenant-base/chart/templates/kafkatopic.yaml
+++ b/charts/tenant-base/chart/templates/kafkatopic.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.kafkaTopics }}
+{{- range .Values.kafkaTopics.create }}
 # https://strimzi.io/docs/operators/latest/configuring.html#type-KafkaTopic-reference
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -1,3 +1,4 @@
+---
 # Allows for renaming of the chart, this is advised since the pods would include 'tenant-base' as the name otherwise.
 fullnameOverride: foobar
 
@@ -98,27 +99,37 @@ configMaps:
 # The bucketClaim creates a secret and configMap that needs to be mounted on the pod that will use it.
 # The name of the secret and configMap is <name>-bucket.
 bucketClaims:
-  # - name: foobar
+# - name: foobar
 
 # Persistent Volume claims allows for the creation of a volume that will persist even if the pod it's mounted on is destroyed.
 persistentVolumeClaims:
-  # - name: foobar
-  #   size: 8Gi
-  #   # Optional
-  #   storageClassName: standard
-
+# - name: foobar
+#   size: 8Gi
+#   # Optional
+#   storageClassName: standard
 # This is a reference to the clusterSecretStore located on the cluster.
 secretStore:
   name: default
   kind: ClusterSecretStore
-
-# List of Kafka topics to create.
-# Note: The example shows the only supported configuration fields of a Kafka topic with the default values.
-# If you need to do more advanced configuration of a Kafka topics, please contact the maintainers, so they can add support for the requested configuration field.
-kafkaTopics: []
-#  - name: "example-topic"  #(required)
-#    replicas: 3
-#    partitions: 1
-#    retention:
-#      ms: 604800000 # 7 days
-#      bytes: -1
+kafkaTopics:
+  # List of Kafka topics to create. You still need to configure the access to the topic in the 'access' block to give applications access to produce or consume to a topic.
+  # In practice this generates a KafkaTopic resource in the namespace of the tenant which is the copied to the namespace of the Kafka cluster. This means that the KafkaTopic resource in the tenant namespace will not become Ready even tough its clone in Ready.
+  # Requirements: The name of the topics must include the tenants namespace name as prefix. This is to avoid naming collisions between different tenants' Kafka topics.
+  #
+  #
+  # Note: The example shows the only supported configuration fields of a Kafka topic with the default values.
+  # If you need to do more advanced configuration of a Kafka topics, please contact the maintainers, so they can add support for the requested configuration field.
+  create: []
+  #  - name: "example-topic"                  #(required)
+  #    replicas: 3
+  #    partitions: 1
+  #    retention:
+  #      ms: 604800000                        #7days
+  #      bytes: -1                            #No byte retention
+  #  List of Kafka topics to access.
+  access: []
+  #  - name: "tenant-test-topic"              #(required)
+  #    applicationName: "kafka-test-produce"  #(required)
+  #    namespace: "tenant-test"               #(required)
+  #    produce: false                         #(required)
+  #    consume: false                         #(required)


### PR DESCRIPTION
**Description of your changes:**
Through a ConfigMap a deployment can now configure if a deployment should be able to communicate with Kafka. A deployment can be configured to produce and consume to specific Kafka topics.

The ConfigMap will be digested by Kyverno which will generate the appropriate CiliumNetworkPolicy

Related PR:
https://dev.azure.com/energinet/Team%20DT/_git/flux-fleet-repo/pullrequest/28392


Checklist:

* [x] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
