### PR TITLE
Remove live/readi - ness probes from values.yaml

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.6.0
+version: 0.7.0

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -40,9 +40,15 @@ spec:
               protocol: {{ .protocol }}
           {{- end }}
           livenessProbe:
-            {{- toYaml .livenessProbe | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: 9898
           readinessProbe:
-            {{- toYaml .readinessProbe | nindent 12 }}
+            httpGet:
+              path: /healthz
+              port: 9898
+          resources:
+            {{- toYaml .resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .volumeMounts | nindent 12 }}
           {{- with .secrets }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -17,18 +17,6 @@ deployments:
     # The amount of replicas wanted of this container
     replicaCount: 3
 
-    # Liveness probes are used to determine what state the application is in, and allows k8s to remedy a broken state, by e.g. restarting the pod.
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 9898
-
-    # Readiness probes lets k8s know when a pod is ready to accept traffic.
-    readinessProbe:
-      httpGet:
-        path: /healthz
-        port: 9898
-
     # The volumes list defines what types of volumes to provide to the pod.
     # In general we only recommend using the following:
     # * configMaps https://kubernetes.io/docs/concepts/storage/volumes/#configmap

--- a/charts/tenant-base/docs/deployment.md
+++ b/charts/tenant-base/docs/deployment.md
@@ -52,9 +52,9 @@ The liveness probe is used to determine whether the container is running, if the
 
 The readiness probe is used to determine if the container is ready to respond to requests.
 
->It is recommended to always supply both liveness and readiness probes.
+This chart configures liveness and readiness probes to check a HTTP endpoint on port `9898`. The endpoint is expected to return with a `200` HTTP code at `/healthz` if the application is ready and healthy.
 
-There are several ways of configuring both of the probes depending on what type of probe e.g. HTTP or CMD, and we would recommend looking at the [official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes).
+For ASP.NET Core applications the [AspNetCore.Diagnostics.HealthChecks](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) package can be used for adding health check endpoints as explained in [this article](https://andrewlock.net/deploying-asp-net-core-applications-to-kubernetes-part-6-adding-health-checks-with-liveness-readiness-and-startup-probes/#creating-a-custom-health-check)
 
 ## Volumes
 


### PR DESCRIPTION
**Description of your changes:**

Waiting on [helm-charts#399](https://github.com/distributed-technologies/helm-charts/pull/399)

These values has been hardcoded into the deployment, so that we can provide the users a standard way to interact with the liveness and readiness probes.


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
