### PR TITLE
Feature/kafka only crds

### DIFF
--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.1.3
 
 dependencies:
 - name: strimzi-kafka-operator
-  version: "0.27.1"
+  version: "0.31.1"
   repository: "https://strimzi.io/charts/"
 - name: prometheus-kafka-exporter
   version: "1.1.0"

--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
@@ -5,14 +6,14 @@ type: application
 version: 1.2.0
 
 dependencies:
-- name: strimzi-kafka-operator
-  version: "0.31.1"
-  repository: "https://strimzi.io/charts/"
-- name: prometheus-kafka-exporter
-  version: "1.1.0"
-  repository: "https://prometheus-community.github.io/helm-charts"
-  condition: prometheus-kafka-exporter.enabled
-- name: cp-helm-charts
-  version: 0.6.1
-  repository: https://confluentinc.github.io/cp-helm-charts/
-  condition: cp-helm-charts.enabled
+  - name: strimzi-kafka-operator
+    version: "0.31.1"
+    repository: "https://strimzi.io/charts/"
+  - name: prometheus-kafka-exporter
+    version: "1.1.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheus-kafka-exporter.enabled
+  - name: cp-helm-charts
+    version: 0.6.1
+    repository: https://confluentinc.github.io/cp-helm-charts/
+    condition: cp-helm-charts.enabled

--- a/charts/kafka/chart/Chart.yaml
+++ b/charts/kafka/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
 type: application
-version: 1.1.3
+version: 1.2.0
 
 dependencies:
 - name: strimzi-kafka-operator

--- a/charts/kafka/chart/templates/cm-kafka-metrics.yaml
+++ b/charts/kafka/chart/templates/cm-kafka-metrics.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.onlyOperator }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -160,3 +161,4 @@ data:
       labels:
         replicaId: "$2"
         memberType: "$3"
+{{ end }}

--- a/charts/kafka/chart/templates/kafka-operator.yaml
+++ b/charts/kafka/chart/templates/kafka-operator.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.onlyOperator }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -134,3 +135,4 @@ spec:
     {{- if .Values.cluster.kafkaExporter.resources }}
     resources: {{- .Values.cluster.kafkaExporter.resources | toYaml | nindent 6 }}
     {{- end }}
+{{ end }}

--- a/charts/kafka/chart/templates/kafka-topic-template.yaml
+++ b/charts/kafka/chart/templates/kafka-topic-template.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.onlyOperator }}
 {{- range .Values.topics }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
@@ -14,3 +15,4 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{ end }}

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -8,7 +8,8 @@ strimzi-kafka-operator:
 cluster:
   name: my-cluster
   kafka:
-    version: 2.8.0
+    # Supported versions 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.2.1, 3.2.3
+    version: 3.1.2
     storage:
       class: standard
       size: 500Mi

--- a/charts/kafka/chart/values.yaml
+++ b/charts/kafka/chart/values.yaml
@@ -1,4 +1,6 @@
 env: prod
+# Install only the Operators,the CRDS and the cluster wide resources
+onlyOperator: false
 # Docs https://github.com/strimzi/strimzi-kafka-operator/blob/main/helm-charts/helm3/strimzi-kafka-operator/values.yaml
 strimzi-kafka-operator:
   generateNetworkPolicy: false


### PR DESCRIPTION
**Description of your changes:**
The helm chart does not support only installing the operator, CRDS and cluster-wide resources. We need to do this due to the need to deploy only CRDS early in Flux

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
