### PR TITLE
tenant-base: Ensure the cm name is not longer than 64 chars

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.8.1
+version: 0.8.2

--- a/charts/tenant-base/chart/templates/configmap-kafka-topic.yaml
+++ b/charts/tenant-base/chart/templates/configmap-kafka-topic.yaml
@@ -3,8 +3,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafkatopic--{{ .name }}--accessed-by--{{.applicationName}}
-  labels: 
+  {{- /*
+  Truncate the name as Kyverno sets the name as a lable on the generated CiliumNetworkPolicy and Kubernetes does not allow lable values that are more than 63 chars
+  */}}
+  name: {{ trunc 63 ( printf "%s-%s" "kafkatopic-access" (lower (sha256sum (cat .name .applicationName )))) }}
+  labels:
+    {{- /*
+    This label is what triggers the Kyverno policy and should not be changed unless the ClusterPolicy is changed as well.
+    */}}
     kyverno.digest/configmap: "generate-cilium-network-policy-for-kafka-topic"
   annotations:
     kubernetes.io/description: "ConfigMap digested by Kyverno to give the application {{ .applicationName }} in the {{ .namespace }} access to the KafkaTopic {{ .name }}"


### PR DESCRIPTION
When the configmap is digested by Kyverno the cm name is set as a lable value on the generated resource. This value cannot be more than 63 chars.

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
