### PR TITLE
Revert "Change labels to better fix best practice in our usecase"

### DIFF
--- a/charts/tenant-base/README.md
+++ b/charts/tenant-base/README.md
@@ -2,8 +2,6 @@
 
 The tenant base helm chart is a chart that give an easy all in one place to make deployments, it is only designed to make deployments and the resources that could be useful for deployments, like configmaps, pvc's etc.
 
-The name of helm release should be the name of the higher level application that this chart deploys, e.g. if we're deploying a web application and a database, we could call the whole release "wordpress".
-
 The chart is made in a way that allows for creation of a number of resources using only the `values.yaml` file,
 the chart supports the creation of the following resources in some way:
 
@@ -17,6 +15,32 @@ the chart supports the creation of the following resources in some way:
 The `values.yaml` consists of several lists of resources, these are either lists with simple objects e.g. the bucketClaim list only takes a name, or more complex objects like the deployments.
 
 To begin with we will start with the values that are not lists:
+
+### `fullenameOverride`
+
+[`fullnameOverride`](chart/values.yaml#l2) is used to override the name of the chart, the reason this exists is because the name of the chart is `tenant-base` and the name is used in the names of most of the resources, so if we could'nt change the name we would end up with a lot of resources that contains the name of this chart instead of the application the resource actually belong to.
+
+For example if we set `fullnameOverride` to an empty string and use the chart name we get pods that is names:
+
+```bash
+podinfo-tenant-base-podinfo-57c9487678-d6s2z
+podinfo-tenant-base-podinfo-57c9487678-q6lgc
+podinfo-tenant-base-podinfo-57c9487678-x9j6
+```
+
+As we can see `tenant-base` is the middle of the name.
+
+If we set the value of `fullnameOverride` to e.g. `foobar` we would get
+
+```bash
+podinfo-foobar-podinfo-57c9487678-d6s2z
+podinfo-foobar-podinfo-57c9487678-q6lgc
+podinfo-foobar-podinfo-57c9487678-x9j6
+```
+
+Now `tenant-base` has been replaced with `foobar`.
+
+> The structure of the name is built like this `<release-name>-<chart-name or fullnameOverride>-<deployment-name>-<uid>`
 
 ### Deployments
 

--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.8.0
+version: 0.8.1

--- a/charts/tenant-base/chart/templates/_helpers.tpl
+++ b/charts/tenant-base/chart/templates/_helpers.tpl
@@ -1,23 +1,64 @@
 {{/*
-Common labels
-Takes a dictionary contaning containing:
- - 'name'=<The name to use in the labels>,
- - 'values'=<The map of the relative values from a loop>,
- - 'root'=<The root values - used to access ".Release.Name"> - optional - if not present the value will be retrived from .values
+Expand the name of the chart.
 */}}
-{{- define "chart.labels" -}}
-{{ include "chart.selectorLabels" (dict "name" .name)}}
-app.kubernetes.io/version: {{ .values.image.tag }}
-app.kubernetes.io/part-of: {{ .root.Release.Name }}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-SelectorLabels
-Takes a dictionary contaning containing: 'name'=string
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
 */}}
 {{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ .name }}
-app.kubernetes.io/instance: {{ .name }}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -30,5 +71,6 @@ topologySpreadConstraints:
     whenUnsatisfiable: DoNotSchedule
     labelSelector:
       matchLabels:
-        {{- include "chart.selectorLabels" (dict "name" .name) | nindent 8 }}
+        {{- include "chart.selectorLabels" .root | nindent 8 }}
+        app.kubernetes.io/app: {{ .name }}
 {{- end }}

--- a/charts/tenant-base/chart/templates/configmap.yaml
+++ b/charts/tenant-base/chart/templates/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) .name }}
 data:
   {{- .content | toYaml | nindent 2 }}
 {{ end -}}

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -1,17 +1,19 @@
 {{- range $name, $val := .Values.deployments }}
 {{- if .enabled }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
-    {{- include "chart.labels" (dict "name" $name "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   replicas: {{ .replicaCount }}
   selector:
     matchLabels:
-      {{- include "chart.selectorLabels" (dict "name" $name) | nindent 6 }}
+      {{- include "chart.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/app: {{ $name }}
   template:
     metadata:
       {{- with .podAnnotations }}
@@ -19,7 +21,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "chart.selectorLabels" (dict "name" $name) | nindent 8 }}
+        {{- include "chart.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/app: {{ $name }}
     spec:
       {{- include "chart.topologySpreadConstrains" (dict "root" $ "values" $val "name" $name) | nindent 6 }}
       imagePullSecrets:
@@ -52,7 +55,7 @@ spec:
           envFrom:
             {{- range . }}
             - secretRef:
-                name: {{ printf "%s-%s" $name .name }}
+                name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
             {{- end }}
           {{- end }}
       volumes:

--- a/charts/tenant-base/chart/templates/externalsecret.yaml
+++ b/charts/tenant-base/chart/templates/externalsecret.yaml
@@ -6,16 +6,16 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ printf "%s-%s" $name .name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
-    {{- include "chart.labels" (dict "name" (printf "%s-%s" $name .name) "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   refreshInterval: "5m"
   secretStoreRef:
     name: "default"
     kind: "ClusterSecretStore"
   target:
-    name: {{ printf "%s-%s" $name .name }}
+    name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   dataFrom:
   - extract:
       key: {{ .key }}

--- a/charts/tenant-base/chart/templates/kafkatopic.yaml
+++ b/charts/tenant-base/chart/templates/kafkatopic.yaml
@@ -3,15 +3,14 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name .name }}
+  name: {{ .name }}
   labels:
-    {{- include "chart.selectorLabels" (dict "name" .name) | nindent 4 }}
     strimzi.io/cluster: my-cluster
-spec:
+spec: 
   topicName: {{ .name }}
   partitions: {{ .partitions }}
   replicas: {{  .replicas }}
-  config:
+  config: 
     # https://kafka.apache.org/documentation/#topicconfigs
     {{- $retention := .retention | default dict }}
     retention.ms: {{ $retention.ms | default  604800000 }}

--- a/charts/tenant-base/chart/templates/networkpolicy.yaml
+++ b/charts/tenant-base/chart/templates/networkpolicy.yaml
@@ -1,17 +1,19 @@
 {{- range $name, $val := .Values.deployments }}
 {{- if .enabled }}
+
 {{- if .networkPolicy }}
 {{- if or .networkPolicy.ingress .networkPolicy.egress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
-    {{- include "chart.labels" (dict "name" $name "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "chart.selectorLabels" (dict "name" $name) | nindent 6 }}
+      {{- include "chart.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/app: {{ $name }}
   policyTypes:
     {{- if .networkPolicy.ingress }}
     - Ingress

--- a/charts/tenant-base/chart/templates/persistantVolumeClaim.yaml
+++ b/charts/tenant-base/chart/templates/persistantVolumeClaim.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name .name }}
+  name: {{ .name }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/tenant-base/chart/templates/service.yaml
+++ b/charts/tenant-base/chart/templates/service.yaml
@@ -4,9 +4,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $name }}
+  name: {{ printf "%s-%s" (include "chart.fullname" $) $name }}
   labels:
-    {{- include "chart.labels" (dict "name" $name "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   ports:
 {{- range .ports }}
@@ -16,6 +16,7 @@ spec:
       protocol: {{ .protocol }}
 {{- end }}
   selector:
-    {{- include "chart.selectorLabels" (dict "name" $name) | nindent 6 }}
+    {{- include "chart.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/app: {{ $name }}
 {{ end -}}
 {{ end -}}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -1,4 +1,7 @@
 ---
+# Allows for renaming of the chart, this is advised since the pods would include 'tenant-base' as the name otherwise.
+fullnameOverride: foobar
+
 # A list of deployments, this allows for multiple deployments in the same chart.
 deployments:
   # Name of the deployments - this is appended on the deployment and service name.

--- a/charts/tenant-base/docs/deployment.md
+++ b/charts/tenant-base/docs/deployment.md
@@ -16,7 +16,7 @@ deployments:
 ```
 
 [`name`](../chart/values.yaml#l7) is the name of the deployment, this should be descriptive of what this deployment deploys.
-This name is also being used to in the name of the pods.
+This name is also being used to in the name of the pods, like we saw in [fullnameOverride](../README.md#fullenameoverride).
 
 Name is also the key of the deployment object.
 


### PR DESCRIPTION
Reverts distributed-technologies/helm-charts#403

The changes break a lot of functionality. 
1. New naming of KafkaTopic resources -> Breaks Kyverno generate policy that generates Kafka topics[1]
2. Removed label "app.kubernetes.io/app" from deployment pods -> breaks CiliumNetworkPolicy access to KafkaTopics[2]

These are critical features that we found and therefore we choose to revert the whole PR.

[1]https://dev.azure.com/energinet/Team%20DT/_git/flux-fleet-repo?path=/infrastructure/kyverno/kyverno-policies/base/generate_kafka_topic.yaml&version=GBfeature/prometheus-tenant-access&line=33&lineEnd=34&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
[2]https://dev.azure.com/energinet/Team%20DT/_git/flux-fleet-repo?path=/infrastructure/kyverno/kyverno-policies/base/generate_cilium_network_policy_for_kafka_topic.yaml&version=GBfeature/prometheus-tenant-access&line=69&lineEnd=70&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents