### PR TITLE
tenant-base: Implemented possibility to mount configmaps as environment variables

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.8.0
+version: 0.8.3

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -48,12 +48,14 @@ spec:
             {{- toYaml .resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .volumeMounts | nindent 12 }}
-          {{- with .secrets }}
           envFrom:
-            {{- range . }}
-            - secretRef:
-                name: {{ printf "%s-%s" $name .name }}
-            {{- end }}
+          {{- range .secrets }}
+          - secretRef:
+              name: {{ printf "%s-%s" $name .name }}
+          {{- end }}
+          {{- range .configMaps }}
+          - configMapRef:
+              name: {{ printf "%s-%s" $name .name }}
           {{- end }}
       volumes:
         {{- toYaml .volumes | nindent 8 }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -50,14 +50,17 @@ deployments:
       # - name: token
       #   key: secret/tenant-foobar/token
 
+    # A list of config maps that should be mounted into the main pod as environment variables
+    configMaps:
+      []
+    # - name: foobar
+
 # The configMap allows for storage of non secret configurations.
 configMaps:
   []
-  # - name: foobar
-  #   content:
-  #     debug: true
-  #     bar-config.ini: |
-  #       apiKey: qwertyuiop1234567890
+# - name: foobar
+#   content:
+#     apiKey: qwertyuiop1234567890
 
 # Persistent Volume claims allows for the creation of a volume that will persist even if the pod it's mounted on is destroyed.
 persistentVolumeClaims:

--- a/charts/tenant-base/docs/deployment.md
+++ b/charts/tenant-base/docs/deployment.md
@@ -122,6 +122,14 @@ The `podPort` tell us what port on the pod we want to map to the `servicePort` o
 
 This list also adds the secret to the pod as environment variables.
 
+## configMaps
+
+> [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
+
+[`ConfigMaps`](../chart/values.yaml#54) is a list that describes which configMaps to mount into the main pod as environment variables.
+
+[`name`](../chart/values.yaml#56) is a arbitrary name for the configmap, that has to match the defined configMap you would like to mount in.
+
 ## `networkPolicy`
 
 `networkPolicy` controls how traffic can flow to (`ingress`) and from (`egress`) the pods created by the deployment.


### PR DESCRIPTION
**Description of your changes:**
I have added the possibility for our tenants to mount a configmap as environment variables in a pod. This is done to make it easier for tenants to use environment variables in their pods and easier for them to understand how to mount them.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [x] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
