### PR TITLE
Prefix namespace in the spec of KafkaTopic

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.8.5
+version: 0.8.6

--- a/charts/tenant-base/chart/templates/kafkatopic.yaml
+++ b/charts/tenant-base/chart/templates/kafkatopic.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "chart.selectorLabels" (dict "name" .name) | nindent 4 }}
     strimzi.io/cluster: my-cluster
 spec:
-  topicName: {{ .name }}
+  topicName: {{ printf "%s-%s" $.Release.Namespace .name }}
   partitions: {{ .partitions }}
   replicas: {{  .replicas }}
   config:


### PR DESCRIPTION
In the latest release we only did it in the CR metadata, this does not create the Kafka topic with the corret name in the backend.

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
