### PR TITLE
Remove labels from network policies

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.9.2
+version: 0.9.3

--- a/charts/tenant-base/chart/templates/networkpolicy.yaml
+++ b/charts/tenant-base/chart/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@
 {{- if .enabled }}
 {{- if .networkPolicy }}
 {{- if or .networkPolicy.ingress .networkPolicy.egress }}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -25,9 +26,9 @@ spec:
     {{- $ports := .ports }}
     {{- range .networkPolicy.ingress }}
     - from:
-        - podSelector:
-            matchLabels:
-              {{- toYaml .labels | nindent 14 }}
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ printf "%s-%s" .releaseName .deploymentName }}
       ports:
         {{- range .ports }}
           {{- $port := . }}
@@ -41,9 +42,9 @@ spec:
   egress:
     {{- range .networkPolicy.egress }}
     - to:
-        - podSelector:
-            matchLabels:
-              {{- toYaml .labels | nindent 14 }}
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ printf "%s-%s" .releaseName .deploymentName }}
       ports:
         {{- range .ports }}
         - {{ . | toYaml | indent 10 | trim }}

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -22,6 +22,8 @@ deployments:
         servicePort: 80
         protocol: TCP
 
+    # To allow traffic between different pods in your namespace, you have to create ingress and egress rules.
+    # See [this link](https://github.com/distributed-technologies/helm-charts/blob/main/charts/tenant-base/docs/deployment.md#networkpolicy) for more.
     networkPolicy:
       ingress: []
       egress: []

--- a/charts/tenant-base/docs/deployment.md
+++ b/charts/tenant-base/docs/deployment.md
@@ -115,18 +115,18 @@ deployments:
 
     networkPolicy:
       ingress:
-        - labels:
-            app.kubernetes.io/name: foo
+        - releaseName: dlr
+          deploymentName: data
           ports:
             - http
       egress:
-        - labels:
-            app.kubernetes.io/name: foo
+        - releaseName: dlr
+          deploymentName: data
           ports:
             - protocol: TCP
               port: 8080
 ```
 
-This would allow traffic to flow from pods with the label `app.kubernetes.io/name: foo` to the pods created by the deployment on the port defined with `podPortName: http` in `ports`.
+This allows incoming traffic(ingress) to the pod from pods in the dlr helm release that is under the 'data' deployment. This is done on port http, which is defined under `ports`.
 
-It would also allow traffic to flow from the pods creatd by this deployment to pods with the label `app.kubernetes.io/name: foo` on port `8080/TCP`.
+This also allows outgoing traffic(egress) from the pod to pods in the same 'data' deployment under the dlr helm release on port `8080/TCP`.


### PR DESCRIPTION
**Description of your changes:**
We do not want our users to deal with labels in the network policies as this subject is already complicated enough as is. They now have to deal with release name and deployment name instead.

Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
