### PR TITLE
Add 'fullName' variables to all templates that uses the 'release.Name-Name' repeatedly

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.9.1
+version: 0.9.2

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -1,17 +1,18 @@
 {{- range $deploymentName, $val := .Values.deployments }}
+{{- $fullName := (printf "%s-%s" $.Release.Name $deploymentName) }}
 {{- if .enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $deploymentName }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" (dict "name" $deploymentName "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" (dict "name" $fullName "values" $val "root" $) | nindent 4 }}
 spec:
   replicas: {{ .replicaCount }}
   selector:
     matchLabels:
-      {{- include "chart.selectorLabels" (dict "name" $deploymentName) | nindent 6 }}
+      {{- include "chart.selectorLabels" (dict "name" $fullName) | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -24,13 +25,13 @@ spec:
             {{- end -}}
           {{- end }}
       labels:
-        {{- include "chart.selectorLabels" (dict "name" $deploymentName) | nindent 8 }}
+        {{- include "chart.selectorLabels" (dict "name" $fullName) | nindent 8 }}
     spec:
-      {{- include "chart.topologySpreadConstrains" (dict "root" $ "values" $val "name" $deploymentName) | nindent 6 }}
+      {{- include "chart.topologySpreadConstrains" (dict "root" $ "values" $val "name" $fullName) | nindent 6 }}
       imagePullSecrets:
         - name: registry-token
       containers:
-        - name: {{ $deploymentName }}
+        - name: {{ $fullName }}
           securityContext:
             {{- toYaml .securityContext | nindent 12 }}
           image: {{ printf "%s:%s" .image.repository .image.tag }}

--- a/charts/tenant-base/chart/templates/externalsecret.yaml
+++ b/charts/tenant-base/chart/templates/externalsecret.yaml
@@ -1,18 +1,19 @@
 {{- range .Values.secrets }}
+{{- $fullName := (printf "%s-%s" $.Release.Name .name) }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name .name }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" (dict "name" (printf "%s-%s" $.Release.Name .name) "root" $) | nindent 4 }}
+    {{- include "chart.labels" (dict "name" $fullName "root" $) | nindent 4 }}
 spec:
   refreshInterval: "5m"
   secretStoreRef:
     name: "default"
     kind: "ClusterSecretStore"
   target:
-    name: {{ printf "%s-%s" $.Release.Name .name }}
+    name: {{ $fullName }}
   dataFrom:
   - extract:
       key: {{ .key }}

--- a/charts/tenant-base/chart/templates/kafkatopic.yaml
+++ b/charts/tenant-base/chart/templates/kafkatopic.yaml
@@ -1,14 +1,15 @@
 {{- range .Values.kafkaTopics.create }}
+{{- $fullName := (printf "%s-%s" $.Release.Name .name) }}
 # https://strimzi.io/docs/operators/latest/configuring.html#type-KafkaTopic-reference
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: {{ printf "%s-%s" $.Release.Namespace .name }}
+  name: {{ $fullName}}
   labels:
-    {{- include "chart.selectorLabels" (dict "name" .name) | nindent 4 }}
+    {{- include "chart.selectorLabels" (dict "name" $fullName) | nindent 4 }}
     strimzi.io/cluster: my-cluster
 spec:
-  topicName: {{ printf "%s-%s" $.Release.Namespace .name }}
+  topicName: {{ $fullName}}
   partitions: {{ .partitions }}
   replicas: {{  .replicas }}
   config:

--- a/charts/tenant-base/chart/templates/networkpolicy.yaml
+++ b/charts/tenant-base/chart/templates/networkpolicy.yaml
@@ -1,17 +1,18 @@
 {{- range $deploymentName, $val := .Values.deployments }}
+{{- $fullName := (printf "%s-%s" $.Release.Name $deploymentName) }}
 {{- if .enabled }}
 {{- if .networkPolicy }}
 {{- if or .networkPolicy.ingress .networkPolicy.egress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $deploymentName }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" (dict "name" $deploymentName "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" (dict "name" $fullName "values" $val "root" $) | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "chart.selectorLabels" (dict "name" $deploymentName) | nindent 6 }}
+      {{- include "chart.selectorLabels" (dict "name" $fullName) | nindent 6 }}
   policyTypes:
     {{- if .networkPolicy.ingress }}
     - Ingress

--- a/charts/tenant-base/chart/templates/service.yaml
+++ b/charts/tenant-base/chart/templates/service.yaml
@@ -1,12 +1,13 @@
 {{- range $deploymentName, $val := .Values.deployments }}
+{{- $fullName := (printf "%s-%s" $.Release.Name $deploymentName) }}
 {{- if .enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $deploymentName }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" (dict "name" $deploymentName "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" (dict "name" $fullName "values" $val "root" $) | nindent 4 }}
 spec:
   ports:
 {{- range .ports }}
@@ -16,6 +17,6 @@ spec:
       protocol: {{ .protocol }}
 {{- end }}
   selector:
-    {{- include "chart.selectorLabels" (dict "name" $deploymentName) | nindent 6 }}
+    {{- include "chart.selectorLabels" (dict "name" $fullName) | nindent 6 }}
 {{ end -}}
 {{ end -}}

--- a/charts/tenant-base/chart/templates/servicemonitor.yaml
+++ b/charts/tenant-base/chart/templates/servicemonitor.yaml
@@ -1,12 +1,13 @@
 {{- range $deploymentName, $val := .Values.deployments }}
+{{- $fullName := (printf "%s-%s" $.Release.Name $deploymentName) }}
 {{- if .enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ printf "%s-%s" $.Release.Name $deploymentName }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" (dict "name" $deploymentName "values" $val "root" $) | nindent 4 }}
+    {{- include "chart.labels" (dict "name" $fullName "values" $val "root" $) | nindent 4 }}
 spec:
   endpoints:
     {{- range .ports }}
@@ -19,6 +20,6 @@ spec:
     - {{ $.Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "chart.labels" (dict "name" $deploymentName "values" $val "root" $) | nindent 6 }}
+      {{- include "chart.labels" (dict "name" $fullName "values" $val "root" $) | nindent 6 }}
 {{ end -}}
 {{- end }}


### PR DESCRIPTION
**Description of your changes:**

This should make labels display the same as metadata.name does.
fixing bug/331814

Checklist:

* [ x] I have bumped the chart version
* [ x] I have documented my changes if this is needed
* [ x] I have described my changes in the "description of your changes" field
* [ x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ x] I have created the necessary tests in the chart, if they are possible/necessary
* [ x] I have squashed commits if necessary
