### PR TITLE
ci: Fix broken minikube by using version shipped in the runner image

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -42,11 +42,7 @@ jobs:
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./yamllint/config.yaml
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
-        with:
-          minikube version: "v1.27.1"
-          kubernetes version: "v1.25.0"
-          github token: ${{ secrets.GITHUB_TOKEN }}
+        run: minikube start --kubernetes-version v1.25.0
 
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml --upgrade --helm-extra-args "--timeout 7200s"


### PR DESCRIPTION
actions-setup-minikube broke somehow and it is likely fixed in
v2.7.2[1], but using the minikube version in the runner image should be
less fragile.

[1] https://github.com/manusa/actions-setup-minikube/releases/tag/v2.7.2

---

**Description of your changes:**


Checklist:

* [ ] I have bumped the chart version
* [ ] I have documented my changes if this is needed
* [ ] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [ ] I have squashed commits if necessary
