### PR TITLE
Conforming to the k8s resource label naming conventions

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.9.3
+version: 0.9.4

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           {{- range $_, $allConfigMap := $.Values.configMaps -}}
             {{- range $_, $deploymentConfigMap := $val.configMaps -}}
               {{- if eq $allConfigMap.name $deploymentConfigMap.name }}
-                {{- printf "%s/%s: %s" "checksum/configmap" $allConfigMap.name ($allConfigMap | toYaml | toString | sha256sum) | nindent 8 }}
+                {{- printf "%s/%s: %s" "checksum-configmap" $allConfigMap.name ($allConfigMap | toYaml | toString | sha256sum) | nindent 8 }}
               {{- end -}}
             {{- end -}}
           {{- end }}


### PR DESCRIPTION
More than one / is not allowed in the label name of a Kubernetes resource

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [x] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
