### PR TITLE
Enable configurable probes

### DIFF
--- a/charts/tenant-base/chart/Chart.yaml
+++ b/charts/tenant-base/chart/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tenant-base
 description: A basic Helm chart for tenants
 type: application
-version: 0.9.5
+version: 0.10.0

--- a/charts/tenant-base/chart/templates/deployment.yaml
+++ b/charts/tenant-base/chart/templates/deployment.yaml
@@ -42,14 +42,24 @@ spec:
               containerPort: {{ .podPort }}
               protocol: {{ .protocol }}
           {{- end }}
+          {{- /* If the "livenessProbe" key does not exist on the deployment in the values file or the value is something that evaluates to false, we use default values */}}
           livenessProbe:
+            {{- if or (not .livenessProbe) (not (hasKey $val "livenessProbe")) }}
             httpGet:
               path: /healthz
               port: 9898
+            {{- else }}
+              {{- toYaml .livenessProbe | nindent 12 }}
+            {{- end }}
+          {{- /* If the "readinessProbe" key does not exist on the deployment in the values file or the value is something that evaluates to false, we use default values */}}
           readinessProbe:
+            {{- if or (not .readinessProbe) (not (hasKey $val "readinessProbe")) }}
             httpGet:
               path: /healthz
               port: 9898
+            {{- else }}
+              {{- toYaml .readinessProbe | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           volumeMounts:

--- a/charts/tenant-base/chart/values.yaml
+++ b/charts/tenant-base/chart/values.yaml
@@ -46,6 +46,14 @@ deployments:
       # - name: foobar
       #   path: /tmp/foo
 
+    # Probes are meant for Kubernets to realise when an application is unhealthy and should be restarted.
+    # This is most likely a http or gRPC endpoint that Kubernetes call to check if the application is responsive.
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+    # ReadynessProbe is used to tell when the application is ready to accept trafic. Until the readinessProbe is successful a Service will not direct trafic to the Pod.
+    readinessProbe: {}
+    # LivenessProve is used to tell if the application is healthy.
+    livenessProbe: {}
+
 # A list of secrets to fetch from the vault and mounted on the main pod.
 secrets:
   []


### PR DESCRIPTION
The users need to be able to set their own probes

**Description of your changes:**


Checklist:

* [x] I have bumped the chart version
* [x] I have documented my changes if this is needed
* [x] I have described my changes in the "description of your changes" field
* [ ] I have tested this change on a running cluster and the Argocd dashboard shows healthy and synced
* [ ] I have created the necessary tests in the chart, if they are possible/necessary
* [x] I have squashed commits if necessary
